### PR TITLE
Make the dependency injection thread safe

### DIFF
--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -199,6 +199,7 @@ namespace BoDi
     public class ObjectContainer : IObjectContainer
     {
         private const string REGISTERED_NAME_PARAMETER_NAME = "registeredName";
+        private static readonly object _syncLock = new object();
 
         /// <summary>
         /// A very simple immutable linked list of <see cref="Type"/>.
@@ -315,163 +316,582 @@ namespace BoDi
             }
         }
 
-        #region Registration types
-
-        private interface IRegistration
+        private class ObjectContainerUnsafe : IObjectContainer
         {
-            object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
-        }
+            private bool isDisposed = false;
 
-        private class TypeRegistration : IRegistration
-        {
-            private readonly Type implementationType;
+            private readonly Dictionary<RegistrationKey, IRegistration> registrations =
+                new Dictionary<RegistrationKey, IRegistration>();
 
-            public TypeRegistration(Type implementationType)
+            private readonly Dictionary<RegistrationKey, object> resolvedObjects =
+                new Dictionary<RegistrationKey, object>();
+
+            private readonly Dictionary<RegistrationKey, object> objectPool = new Dictionary<RegistrationKey, object>();
+            private readonly ObjectContainer baseContainer;
+
+            #region Registration types
+
+            private interface IRegistration
             {
-                this.implementationType = implementationType;
+                object Resolve(ObjectContainerUnsafe container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
             }
 
-            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            private class TypeRegistration : IRegistration
             {
-                var typeToConstruct = GetTypeToConstruct(keyToResolve);
+                private readonly Type implementationType;
 
-                var pooledObjectKey = new RegistrationKey(typeToConstruct, keyToResolve.Name);
-                object obj = container.GetPooledObject(pooledObjectKey);
-
-                if (obj == null)
+                public TypeRegistration(Type implementationType)
                 {
-                    if (typeToConstruct.IsInterface)
-                        throw new ObjectContainerException("Interface cannot be resolved: " + keyToResolve, resolutionPath.ToTypeList());
-
-                    obj = container.CreateObject(typeToConstruct, resolutionPath, keyToResolve);
-                    container.objectPool.Add(pooledObjectKey, obj);
+                    this.implementationType = implementationType;
                 }
 
-                return obj;
-            }
-
-            private Type GetTypeToConstruct(RegistrationKey keyToResolve)
-            {
-                var targetType = implementationType;
-                if (targetType.IsGenericTypeDefinition)
+                public object Resolve(ObjectContainerUnsafe container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
                 {
-                    var typeArgs = keyToResolve.Type.GetGenericArguments();
-                    targetType = targetType.MakeGenericType(typeArgs);
-                }
-                return targetType;
-            }
+                    var typeToConstruct = GetTypeToConstruct(keyToResolve);
 
-            public override string ToString()
-            {
-                return "Type: " + implementationType.FullName;
-            }
-        }
+                    var pooledObjectKey = new RegistrationKey(typeToConstruct, keyToResolve.Name);
+                    object obj = container.GetPooledObject(pooledObjectKey);
 
-        private class InstanceRegistration : IRegistration
-        {
-            private readonly object instance;
+                    if (obj == null)
+                    {
+                        if (typeToConstruct.IsInterface)
+                            throw new ObjectContainerException("Interface cannot be resolved: " + keyToResolve, resolutionPath.ToTypeList());
 
-            public InstanceRegistration(object instance)
-            {
-                this.instance = instance;
-            }
+                        obj = container.CreateObject(typeToConstruct, resolutionPath, keyToResolve);
+                        container.objectPool.Add(pooledObjectKey, obj);
+                    }
 
-            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
-            {
-                return instance;
-            }
-
-            public override string ToString()
-            {
-                string instanceText;
-                try
-                {
-                    instanceText = instance.ToString();
-                }
-                catch (Exception ex)
-                {
-                    instanceText = ex.Message;
+                    return obj;
                 }
 
-                return "Instance: " + instanceText;
-            }
-        }
-
-        private class FactoryRegistration : IRegistration
-        {
-            private readonly Delegate factoryDelegate;
-
-            public FactoryRegistration(Delegate factoryDelegate)
-            {
-                this.factoryDelegate = factoryDelegate;
-            }
-
-            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
-            {
-                var obj = container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
-                return obj;
-            }
-        }
-
-        private class NonDisposableWrapper
-        {
-            public object Object { get; private set; }
-
-            public NonDisposableWrapper(object obj)
-            {
-                Object = obj;
-            }
-        }
-
-        private class NamedInstanceDictionaryRegistration : IRegistration
-        {
-            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
-            {
-                var typeToResolve = keyToResolve.Type;
-                Debug.Assert(typeToResolve.IsGenericType && typeToResolve.GetGenericTypeDefinition() == typeof(IDictionary<,>));
-
-                var genericArguments = typeToResolve.GetGenericArguments();
-                var keyType = genericArguments[0];
-                var targetType = genericArguments[1];
-                var result = (IDictionary)Activator.CreateInstance(typeof (Dictionary<,>).MakeGenericType(genericArguments));
-
-                foreach (var namedRegistration in container.registrations.Where(r => r.Key.Name != null && r.Key.Type == targetType).Select(r => r.Key).ToList())
+                private Type GetTypeToConstruct(RegistrationKey keyToResolve)
                 {
-                    var convertedKey = ChangeType(namedRegistration.Name, keyType);
-                    Debug.Assert(convertedKey != null);
-                    result.Add(convertedKey, container.Resolve(namedRegistration.Type, namedRegistration.Name));
+                    var targetType = implementationType;
+                    if (targetType.IsGenericTypeDefinition)
+                    {
+                        var typeArgs = keyToResolve.Type.GetGenericArguments();
+                        targetType = targetType.MakeGenericType(typeArgs);
+                    }
+                    return targetType;
                 }
 
+                public override string ToString()
+                {
+                    return "Type: " + implementationType.FullName;
+                }
+            }
+
+            private class InstanceRegistration : IRegistration
+            {
+                private readonly object instance;
+
+                public InstanceRegistration(object instance)
+                {
+                    this.instance = instance;
+                }
+
+                public object Resolve(ObjectContainerUnsafe container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+                {
+                    return instance;
+                }
+
+                public override string ToString()
+                {
+                    string instanceText;
+                    try
+                    {
+                        instanceText = instance.ToString();
+                    }
+                    catch (Exception ex)
+                    {
+                        instanceText = ex.Message;
+                    }
+
+                    return "Instance: " + instanceText;
+                }
+            }
+
+            private class FactoryRegistration : IRegistration
+            {
+                private readonly Delegate factoryDelegate;
+
+                public FactoryRegistration(Delegate factoryDelegate)
+                {
+                    this.factoryDelegate = factoryDelegate;
+                }
+
+                public object Resolve(ObjectContainerUnsafe container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+                {
+                    var obj = container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
+                    return obj;
+                }
+            }
+
+            private class NonDisposableWrapper
+            {
+                public object Object { get; private set; }
+
+                public NonDisposableWrapper(object obj)
+                {
+                    Object = obj;
+                }
+            }
+
+            private class NamedInstanceDictionaryRegistration : IRegistration
+            {
+                public object Resolve(ObjectContainerUnsafe container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+                {
+                    var typeToResolve = keyToResolve.Type;
+                    Debug.Assert(typeToResolve.IsGenericType && typeToResolve.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+                    var genericArguments = typeToResolve.GetGenericArguments();
+                    var keyType = genericArguments[0];
+                    var targetType = genericArguments[1];
+                    var result = (IDictionary)Activator.CreateInstance(typeof (Dictionary<,>).MakeGenericType(genericArguments));
+
+                    foreach (var namedRegistration in container.registrations.Where(r => r.Key.Name != null && r.Key.Type == targetType).Select(r => r.Key).ToList())
+                    {
+                        var convertedKey = ChangeType(namedRegistration.Name, keyType);
+                        Debug.Assert(convertedKey != null);
+                        result.Add(convertedKey, container.Resolve(namedRegistration.Type, namedRegistration.Name));
+                    }
+
+                    return result;
+                }
+
+                private object ChangeType(string name, Type keyType)
+                {
+                    if (keyType.IsEnum)
+                        return Enum.Parse(keyType, name, true);
+
+                    Debug.Assert(keyType == typeof(string));
+                    return name;
+                }
+            }
+
+            #endregion
+
+            public ObjectContainer BaseContainer => baseContainer;
+
+            public ObjectContainerUnsafe(ObjectContainer baseContainer)
+            {
+                this.baseContainer = baseContainer;
+            }
+
+            public event Action<object> ObjectCreated;
+
+            public void RegisterTypeAs<TInterface>(Type implementationType, string name = null) where TInterface : class
+            {
+                Type interfaceType = typeof(TInterface);
+                RegisterTypeAs(implementationType, interfaceType, name);
+            }
+
+            public void RegisterTypeAs<TType, TInterface>(string name = null) where TType : class, TInterface
+            {
+                Type interfaceType = typeof(TInterface);
+                Type implementationType = typeof(TType);
+                RegisterTypeAs(implementationType, interfaceType, name);
+            }
+
+            public void RegisterTypeAs(Type implementationType, Type interfaceType)
+            {
+                if(!IsValidTypeMapping(implementationType, interfaceType))
+                    throw new InvalidOperationException("type mapping is not valid");
+                RegisterTypeAs(implementationType, interfaceType, null);
+            }
+
+            public void RegisterInstanceAs(object instance, Type interfaceType, string name = null,
+                bool dispose = false)
+            {
+                if (instance == null)
+                    throw new ArgumentNullException("instance");
+                var registrationKey = new RegistrationKey(interfaceType, name);
+                AssertNotResolved(registrationKey);
+
+                ClearRegistrations(registrationKey);
+                AddRegistration(registrationKey, new InstanceRegistration(instance));
+                objectPool[new RegistrationKey(instance.GetType(), name)] = GetPoolableInstance(instance, dispose);
+            }
+
+            public void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false) where TInterface : class
+            {
+                RegisterInstanceAs(instance, typeof(TInterface), name, dispose);
+            }
+
+            public void RegisterFactoryAs<TInterface>(Func<TInterface> factoryDelegate, string name = null)
+            {
+                RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            }
+
+            public void RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null)
+            {
+                RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            }
+
+            public void RegisterFactoryAs<TInterface>(Delegate factoryDelegate, string name = null)
+            {
+                RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            }
+
+            public void RegisterFactoryAs(Delegate factoryDelegate, Type interfaceType, string name = null)
+            {
+                if (factoryDelegate == null) throw new ArgumentNullException("factoryDelegate");
+                if (interfaceType == null) throw new ArgumentNullException("interfaceType");
+
+                var registrationKey = new RegistrationKey(interfaceType, name);
+                AssertNotResolved(registrationKey);
+
+                ClearRegistrations(registrationKey);
+
+                AddRegistration(registrationKey, new FactoryRegistration(factoryDelegate));
+            }
+
+            public bool IsRegistered<T>()
+            {
+                return this.IsRegistered<T>(null);
+            }
+
+            public bool IsRegistered<T>(string name)
+            {
+                Type typeToResolve = typeof(T);
+
+                var keyToResolve = new RegistrationKey(typeToResolve, name);
+
+                return registrations.ContainsKey(keyToResolve);
+            }
+
+            private bool IsValidTypeMapping(Type implementationType, Type interfaceType)
+            {
+                if (interfaceType.IsAssignableFrom(implementationType))
+                    return true;
+
+                if (interfaceType.IsGenericTypeDefinition && implementationType.IsGenericTypeDefinition)
+                {
+                    var baseTypes = GetBaseTypes(implementationType).ToArray();
+                    return baseTypes.Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType);
+                }
+
+                return false;
+            }
+
+            private static IEnumerable<Type> GetBaseTypes(Type type)
+            {
+                if (type.BaseType == null) return type.GetInterfaces();
+
+                return Enumerable.Repeat(type.BaseType, 1)
+                    .Concat(type.GetInterfaces())
+                    .Concat(type.GetInterfaces().SelectMany(GetBaseTypes))
+                    .Concat(GetBaseTypes(type.BaseType));
+            }
+
+
+            private ObjectContainer.RegistrationKey CreateNamedInstanceDictionaryKey(Type targetType)
+            {
+                return new ObjectContainer.RegistrationKey(
+                    typeof(IDictionary<,>).MakeGenericType(typeof(string), targetType), null);
+            }
+
+            private void AddRegistration(ObjectContainer.RegistrationKey key,
+                ObjectContainerUnsafe.IRegistration registration)
+            {
+                registrations[key] = registration;
+
+                if (key.Name != null)
+                {
+                    var dictKey = CreateNamedInstanceDictionaryKey(key.Type);
+                    if (!registrations.ContainsKey(dictKey))
+                    {
+                        registrations[dictKey] = new ObjectContainerUnsafe.NamedInstanceDictionaryRegistration();
+                    }
+                }
+            }
+
+            private void RegisterTypeAs(Type implementationType, Type interfaceType, string name)
+            {
+                var registrationKey = new ObjectContainer.RegistrationKey(interfaceType, name);
+                AssertNotResolved(registrationKey);
+
+                ClearRegistrations(registrationKey);
+
+                AddRegistration(registrationKey, new ObjectContainerUnsafe.TypeRegistration(implementationType));
+            }
+
+            private static object GetPoolableInstance(object instance, bool dispose)
+            {
+                return (instance is IDisposable) && !dispose ? new NonDisposableWrapper(instance) : instance;
+            }
+
+            // ReSharper disable once UnusedParameter.Local
+            private void AssertNotResolved(RegistrationKey interfaceType)
+            {
+                if (resolvedObjects.ContainsKey(interfaceType))
+                    throw new ObjectContainerException("An object has been resolved for this interface already.", null);
+            }
+
+            private void ClearRegistrations(RegistrationKey registrationKey)
+            {
+                registrations.Remove(registrationKey);
+            }
+
+#if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT
+            public void RegisterFromConfiguration()
+            {
+                var section = (BoDiConfigurationSection)ConfigurationManager.GetSection("boDi");
+                if (section == null)
+                    return;
+
+                RegisterFromConfiguration(section.Registrations);
+            }
+
+            public void RegisterFromConfiguration(ContainerRegistrationCollection containerRegistrationCollection)
+            {
+                if (containerRegistrationCollection == null)
+                    return;
+
+                foreach (ContainerRegistrationConfigElement registrationConfigElement in containerRegistrationCollection)
+                {
+                    RegisterFromConfiguration(registrationConfigElement);
+                }
+            }
+
+            private void RegisterFromConfiguration(ContainerRegistrationConfigElement registrationConfigElement)
+            {
+                Type interfaceType = Type.GetType(registrationConfigElement.Interface, true);
+                Type implementationType = Type.GetType(registrationConfigElement.Implementation, true);
+
+                RegisterTypeAs(implementationType, interfaceType, string.IsNullOrEmpty(registrationConfigElement.Name) ? null : registrationConfigElement.Name);
+            }
+#endif
+
+            public T Resolve<T>()
+            {
+                return Resolve<T>(null);
+            }
+
+            public T Resolve<T>(string name)
+            {
+                Type typeToResolve = typeof(T);
+
+                object resolvedObject = Resolve(typeToResolve, name);
+
+                return (T)resolvedObject;
+            }
+
+            public object Resolve(Type typeToResolve, string name = null)
+            {
+                return Resolve(typeToResolve, new ResolutionList(), name);
+            }
+
+            public IEnumerable<T> ResolveAll<T>() where T : class
+            {
+                return registrations
+                    .Where(x => x.Key.Type == typeof(T))
+                    .Select(x => Resolve (x.Key.Type, x.Key.Name) as T);
+            }
+
+            private object Resolve(Type typeToResolve, ResolutionList resolutionPath, string name)
+            {
+                AssertNotDisposed();
+
+                var keyToResolve = new RegistrationKey(typeToResolve, name);
+                object resolvedObject;
+                if (!resolvedObjects.TryGetValue(keyToResolve, out resolvedObject))
+                {
+                    resolvedObject = ResolveObject(keyToResolve, resolutionPath);
+                    resolvedObjects.Add(keyToResolve, resolvedObject);
+                }
+                Debug.Assert(typeToResolve.IsInstanceOfType(resolvedObject));
+                return resolvedObject;
+            }
+
+            private KeyValuePair<ObjectContainerUnsafe, IRegistration>? GetRegistrationResult(RegistrationKey keyToResolve)
+            {
+                IRegistration registration;
+                if (registrations.TryGetValue(keyToResolve, out registration))
+                {
+                    return new KeyValuePair<ObjectContainerUnsafe, IRegistration>(this, registration);
+                }
+
+                if (baseContainer != null)
+                    return baseContainer._unsafeContainer.GetRegistrationResult(keyToResolve);
+
+                if (IsSpecialNamedInstanceDictionaryKey(keyToResolve))
+                {
+                    var targetType = keyToResolve.Type.GetGenericArguments()[1];
+                    return GetRegistrationResult(CreateNamedInstanceDictionaryKey(targetType));
+                }
+
+                // if there was no named registration, we still return an empty dictionary
+                if (IsDefaultNamedInstanceDictionaryKey(keyToResolve))
+                {
+                    return new KeyValuePair<ObjectContainerUnsafe, IRegistration>(this, new NamedInstanceDictionaryRegistration());
+                }
+
+                return null;
+            }
+
+            private bool IsDefaultNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+            {
+                return IsNamedInstanceDictionaryKey(keyToResolve) &&
+                       keyToResolve.Type.GetGenericArguments()[0] == typeof(string);
+            }
+
+            private bool IsSpecialNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+            {
+                return IsNamedInstanceDictionaryKey(keyToResolve) &&
+                       keyToResolve.Type.GetGenericArguments()[0].IsEnum;
+            }
+
+            private bool IsNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+            {
+                return keyToResolve.Name == null && keyToResolve.Type.IsGenericType && keyToResolve.Type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
+            }
+
+            private object GetPooledObject(RegistrationKey pooledObjectKey)
+            {
+                object obj;
+                if (GetObjectFromPool(pooledObjectKey, out obj))
+                    return obj;
+
+                return null;
+            }
+
+            private bool GetObjectFromPool(RegistrationKey pooledObjectKey, out object obj)
+            {
+                if (!objectPool.TryGetValue(pooledObjectKey, out obj))
+                    return false;
+
+                var nonDisposableWrapper = obj as NonDisposableWrapper;
+                if (nonDisposableWrapper != null)
+                    obj = nonDisposableWrapper.Object;
+
+                return true;
+            }
+
+            private object ResolveObject(RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                if (keyToResolve.Type.IsPrimitive || keyToResolve.Type == typeof(string) || keyToResolve.Type.IsValueType)
+                    throw new ObjectContainerException("Primitive types or structs cannot be resolved: " + keyToResolve.Type.FullName, resolutionPath.ToTypeList());
+
+                var registrationResult = GetRegistrationResult(keyToResolve);
+                var isImplicitTypeRegistration = registrationResult == null;
+                var registrationToUse = registrationResult ?? 
+                    new KeyValuePair<ObjectContainerUnsafe, IRegistration>(this, new TypeRegistration(keyToResolve.Type));
+
+                var resolutionPathForResolve = registrationToUse.Key == this ?
+                    resolutionPath : new ResolutionList();
+                var result = registrationToUse.Value.Resolve(registrationToUse.Key, keyToResolve, resolutionPathForResolve);
+                if (isImplicitTypeRegistration) // upon successful implicit registration, we register the rule, so that sub context can also get the same resolved value
+                    AddRegistration(keyToResolve, registrationToUse.Value);
                 return result;
             }
 
-            private object ChangeType(string name, Type keyType)
+            private object CreateObject(Type type, ResolutionList resolutionPath, RegistrationKey keyToResolve)
             {
-                if (keyType.IsEnum)
-                    return Enum.Parse(keyType, name, true);
+                var ctors = type.GetConstructors();
+                if (ctors.Length == 0)
+                    ctors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
 
-                Debug.Assert(keyType == typeof(string));
-                return name;
+                Debug.Assert(ctors.Length > 0, "Class must have a constructor!");
+
+                int maxParamCount = ctors.Max(ctor => ctor.GetParameters().Length);
+                var maxParamCountCtors = ctors.Where(ctor => ctor.GetParameters().Length == maxParamCount).ToArray();
+
+                object obj;
+                if (maxParamCountCtors.Length == 1)
+                {
+                    ConstructorInfo ctor = maxParamCountCtors[0];
+                    if (resolutionPath.Contains(keyToResolve))
+                        throw new ObjectContainerException("Circular dependency found! " + type.FullName, resolutionPath.ToTypeList());
+
+                    var args = ResolveArguments(ctor.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, type));
+                    obj = ctor.Invoke(args);
+                }
+                else
+                {
+                    throw new ObjectContainerException("Multiple public constructors with same maximum parameter count are not supported! " + type.FullName, resolutionPath.ToTypeList());
+                }
+
+                OnObjectCreated(obj);
+
+                return obj;
+            }
+
+            protected virtual void OnObjectCreated(object obj)
+            {
+                var eventHandler = ObjectCreated;
+                if (eventHandler != null)
+                    eventHandler(obj);
+            }
+
+            private object InvokeFactoryDelegate(Delegate factoryDelegate, ResolutionList resolutionPath, RegistrationKey keyToResolve)
+            {
+                if (resolutionPath.Contains(keyToResolve))
+                    throw new ObjectContainerException("Circular dependency found! " + factoryDelegate.ToString(), resolutionPath.ToTypeList());
+
+                var args = ResolveArguments(factoryDelegate.Method.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, null));
+                return factoryDelegate.DynamicInvoke(args);
+            }
+
+            private object[] ResolveArguments(IEnumerable<ParameterInfo> parameters, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                return parameters.Select(p => IsRegisteredNameParameter(p) ? ResolveRegisteredName(keyToResolve) : Resolve(p.ParameterType, resolutionPath, null)).ToArray();
+            }
+
+            private object ResolveRegisteredName(RegistrationKey keyToResolve)
+            {
+                return keyToResolve.Name;
+            }
+
+            private bool IsRegisteredNameParameter(ParameterInfo parameterInfo)
+            {
+                return parameterInfo.ParameterType == typeof (string) && 
+                       parameterInfo.Name.Equals(REGISTERED_NAME_PARAMETER_NAME);
+            }
+
+            public override string ToString()
+            {
+                return string.Join(Environment.NewLine,
+                    registrations
+                        .Where(r => !(r.Value is NamedInstanceDictionaryRegistration))
+                        .Select(r => string.Format("{0} -> {1}", r.Key, (r.Key.Type == typeof(IObjectContainer) && r.Key.Name == null) ? "<self>" : r.Value.ToString())));
+            }
+
+            private void AssertNotDisposed()
+            {
+                if (isDisposed)
+                    throw new ObjectContainerException("Object container disposed", null);
+            }
+
+            public void Dispose()
+            {
+                isDisposed = true;
+
+                foreach (var obj in objectPool.Values.OfType<IDisposable>().Where(o => !ReferenceEquals(o, this)))
+                    obj.Dispose();
+
+                objectPool.Clear();
+                registrations.Clear();
+                resolvedObjects.Clear();
             }
         }
 
-        #endregion
+        private readonly ObjectContainerUnsafe _unsafeContainer;
 
-        private bool isDisposed = false;
-        private readonly ObjectContainer baseContainer;
-        private readonly Dictionary<RegistrationKey, IRegistration> registrations = new Dictionary<RegistrationKey, IRegistration>();
-        private readonly Dictionary<RegistrationKey, object> resolvedObjects = new Dictionary<RegistrationKey, object>();
-        private readonly Dictionary<RegistrationKey, object> objectPool = new Dictionary<RegistrationKey, object>();
+        public event Action<object> ObjectCreated
+        {
+            add { _unsafeContainer.ObjectCreated += value; }
+            remove { _unsafeContainer.ObjectCreated -= value; }
+        }
 
-        public event Action<object> ObjectCreated;
-        public IObjectContainer BaseContainer => baseContainer;
+        public IObjectContainer BaseContainer => _unsafeContainer.BaseContainer;
 
-        public ObjectContainer(IObjectContainer baseContainer = null) 
+        public ObjectContainer(IObjectContainer baseContainer = null)
         {
             if (baseContainer != null && !(baseContainer is ObjectContainer))
                 throw new ArgumentException("Base container must be an ObjectContainer", "baseContainer");
 
-            this.baseContainer = (ObjectContainer)baseContainer;
+            _unsafeContainer = new ObjectContainerUnsafe((ObjectContainer) baseContainer);
             RegisterInstanceAs<IObjectContainer>(this);
         }
 
@@ -479,181 +899,109 @@ namespace BoDi
 
         public void RegisterTypeAs<TInterface>(Type implementationType, string name = null) where TInterface : class
         {
-            Type interfaceType = typeof(TInterface);
-            RegisterTypeAs(implementationType, interfaceType, name);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterTypeAs<TInterface>(implementationType, name);
+            }
         }
 
         public void RegisterTypeAs<TType, TInterface>(string name = null) where TType : class, TInterface
         {
-            Type interfaceType = typeof(TInterface);
-            Type implementationType = typeof(TType);
-            RegisterTypeAs(implementationType, interfaceType, name);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterTypeAs<TType, TInterface>(name);
+            }
         }
 
         public void RegisterTypeAs(Type implementationType, Type interfaceType)
         {
-            if(!IsValidTypeMapping(implementationType, interfaceType))
-                throw new InvalidOperationException("type mapping is not valid");
-            RegisterTypeAs(implementationType, interfaceType, null);
-        }
-
-        private bool IsValidTypeMapping(Type implementationType, Type interfaceType)
-        {
-            if (interfaceType.IsAssignableFrom(implementationType))
-                return true;
-
-            if (interfaceType.IsGenericTypeDefinition && implementationType.IsGenericTypeDefinition)
+            lock (_syncLock)
             {
-                var baseTypes = GetBaseTypes(implementationType).ToArray();
-                return baseTypes.Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType);
+                _unsafeContainer.RegisterTypeAs(implementationType, interfaceType);
             }
-
-            return false;
-        }
-
-        private static IEnumerable<Type> GetBaseTypes(Type type)
-        {
-            if (type.BaseType == null) return type.GetInterfaces();
-
-            return Enumerable.Repeat(type.BaseType, 1)
-                             .Concat(type.GetInterfaces())
-                             .Concat(type.GetInterfaces().SelectMany(GetBaseTypes))
-                             .Concat(GetBaseTypes(type.BaseType));
-        }
-
-
-        private RegistrationKey CreateNamedInstanceDictionaryKey(Type targetType)
-        {
-            return new RegistrationKey(typeof(IDictionary<,>).MakeGenericType(typeof(string), targetType), null);
-        }
-
-        private void AddRegistration(RegistrationKey key, IRegistration registration)
-        {
-            registrations[key] = registration;
-
-            if (key.Name != null)
-            {
-                var dictKey = CreateNamedInstanceDictionaryKey(key.Type);
-                if (!registrations.ContainsKey(dictKey))
-                {
-                    registrations[dictKey] = new NamedInstanceDictionaryRegistration();
-                }
-            }
-        }
-
-        private void RegisterTypeAs(Type implementationType, Type interfaceType, string name)
-        {
-            var registrationKey = new RegistrationKey(interfaceType, name);
-            AssertNotResolved(registrationKey);
-
-            ClearRegistrations(registrationKey);
-
-            AddRegistration(registrationKey, new TypeRegistration(implementationType));
         }
 
         public void RegisterInstanceAs(object instance, Type interfaceType, string name = null, bool dispose = false)
         {
-            if (instance == null)
-                throw new ArgumentNullException("instance");
-            var registrationKey = new RegistrationKey(interfaceType, name);
-            AssertNotResolved(registrationKey);
-
-            ClearRegistrations(registrationKey);
-            AddRegistration(registrationKey, new InstanceRegistration(instance));
-            objectPool[new RegistrationKey(instance.GetType(), name)] = GetPoolableInstance(instance, dispose);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterInstanceAs(instance, interfaceType, name, dispose);
+            }
         }
 
-        private static object GetPoolableInstance(object instance, bool dispose)
+        public void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false)
+            where TInterface : class
         {
-            return (instance is IDisposable) && !dispose ? new NonDisposableWrapper(instance) : instance;
-        }
-
-        public void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false) where TInterface : class
-        {
-            RegisterInstanceAs(instance, typeof(TInterface), name, dispose);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterInstanceAs(instance, typeof(TInterface), name, dispose);
+            }
         }
 
         public void RegisterFactoryAs<TInterface>(Func<TInterface> factoryDelegate, string name = null)
         {
-            RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            }
         }
 
-        public void RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null)
+        public void RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate,
+            string name = null)
         {
-            RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            }
         }
 
         public void RegisterFactoryAs<TInterface>(Delegate factoryDelegate, string name = null)
         {
-            RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+            }
         }
 
         public void RegisterFactoryAs(Delegate factoryDelegate, Type interfaceType, string name = null)
         {
-            if (factoryDelegate == null) throw new ArgumentNullException("factoryDelegate");
-            if (interfaceType == null) throw new ArgumentNullException("interfaceType");
-
-            var registrationKey = new RegistrationKey(interfaceType, name);
-            AssertNotResolved(registrationKey);
-
-            ClearRegistrations(registrationKey);
-
-            AddRegistration(registrationKey, new FactoryRegistration(factoryDelegate));
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterFactoryAs(factoryDelegate, interfaceType, name);
+            }
         }
 
         public bool IsRegistered<T>()
         {
-            return this.IsRegistered<T>(null);
+            lock (_syncLock)
+            {
+                return _unsafeContainer.IsRegistered<T>(null);
+            }
         }
 
         public bool IsRegistered<T>(string name)
         {
-            Type typeToResolve = typeof(T);
-
-            var keyToResolve = new RegistrationKey(typeToResolve, name);
-
-            return registrations.ContainsKey(keyToResolve);
-        }
-
-        // ReSharper disable once UnusedParameter.Local
-        private void AssertNotResolved(RegistrationKey interfaceType)
-        {
-            if (resolvedObjects.ContainsKey(interfaceType))
-                throw new ObjectContainerException("An object has been resolved for this interface already.", null);
-        }
-
-        private void ClearRegistrations(RegistrationKey registrationKey)
-        {
-            registrations.Remove(registrationKey);
+            lock (_syncLock)
+            {
+                return _unsafeContainer.IsRegistered<T>(name);
+            }
         }
 
 #if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT
         public void RegisterFromConfiguration()
         {
-            var section = (BoDiConfigurationSection)ConfigurationManager.GetSection("boDi");
-            if (section == null)
-                return;
-
-            RegisterFromConfiguration(section.Registrations);
+            lock (_syncLock)
+            {
+                _unsafeContainer.RegisterFromConfiguration();
+            }
         }
 
         public void RegisterFromConfiguration(ContainerRegistrationCollection containerRegistrationCollection)
         {
-            if (containerRegistrationCollection == null)
-                return;
-
-            foreach (ContainerRegistrationConfigElement registrationConfigElement in containerRegistrationCollection)
+            lock (_syncLock)
             {
-                RegisterFromConfiguration(registrationConfigElement);
+                _unsafeContainer.RegisterFromConfiguration(containerRegistrationCollection);
             }
-        }
-
-        private void RegisterFromConfiguration(ContainerRegistrationConfigElement registrationConfigElement)
-        {
-            Type interfaceType = Type.GetType(registrationConfigElement.Interface, true);
-            Type implementationType = Type.GetType(registrationConfigElement.Implementation, true);
-
-            RegisterTypeAs(implementationType, interfaceType, string.IsNullOrEmpty(registrationConfigElement.Name) ? null : registrationConfigElement.Name);
         }
 #endif
 
@@ -663,216 +1011,52 @@ namespace BoDi
 
         public T Resolve<T>()
         {
-            return Resolve<T>(null);
+            lock (_syncLock)
+            {
+                return _unsafeContainer.Resolve<T>();
+            }
         }
 
         public T Resolve<T>(string name)
         {
-            Type typeToResolve = typeof(T);
-
-            object resolvedObject = Resolve(typeToResolve, name);
-
-            return (T)resolvedObject;
+            lock (_syncLock)
+            {
+                return _unsafeContainer.Resolve<T>(name);
+            }
         }
 
         public object Resolve(Type typeToResolve, string name = null)
         {
-            return Resolve(typeToResolve, new ResolutionList(), name);
+            lock (_syncLock)
+            {
+                return _unsafeContainer.Resolve(typeToResolve, name);
+            }
         }
 
         public IEnumerable<T> ResolveAll<T>() where T : class
         {
-            return registrations
-                .Where(x => x.Key.Type == typeof(T))
-                .Select(x => Resolve (x.Key.Type, x.Key.Name) as T);
-        }
-
-        private object Resolve(Type typeToResolve, ResolutionList resolutionPath, string name)
-        {
-            AssertNotDisposed();
-
-            var keyToResolve = new RegistrationKey(typeToResolve, name);
-            object resolvedObject;
-            if (!resolvedObjects.TryGetValue(keyToResolve, out resolvedObject))
+            lock (_syncLock)
             {
-                resolvedObject = ResolveObject(keyToResolve, resolutionPath);
-                resolvedObjects.Add(keyToResolve, resolvedObject);
+                return _unsafeContainer.ResolveAll<T>();
             }
-            Debug.Assert(typeToResolve.IsInstanceOfType(resolvedObject));
-            return resolvedObject;
-        }
-
-        private KeyValuePair<ObjectContainer, IRegistration>? GetRegistrationResult(RegistrationKey keyToResolve)
-        {
-            IRegistration registration;
-            if (registrations.TryGetValue(keyToResolve, out registration))
-            {
-                return new KeyValuePair<ObjectContainer, IRegistration>(this, registration);
-            }
-
-            if (baseContainer != null)
-                return baseContainer.GetRegistrationResult(keyToResolve);
-
-            if (IsSpecialNamedInstanceDictionaryKey(keyToResolve))
-            {
-                var targetType = keyToResolve.Type.GetGenericArguments()[1];
-                return GetRegistrationResult(CreateNamedInstanceDictionaryKey(targetType));
-            }
-
-            // if there was no named registration, we still return an empty dictionary
-            if (IsDefaultNamedInstanceDictionaryKey(keyToResolve))
-            {
-                return new KeyValuePair<ObjectContainer, IRegistration>(this, new NamedInstanceDictionaryRegistration());
-            }
-
-            return null;
-        }
-
-        private bool IsDefaultNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
-        {
-            return IsNamedInstanceDictionaryKey(keyToResolve) && 
-                   keyToResolve.Type.GetGenericArguments()[0] == typeof(string);
-        }
-
-        private bool IsSpecialNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
-        {
-            return IsNamedInstanceDictionaryKey(keyToResolve) && 
-                   keyToResolve.Type.GetGenericArguments()[0].IsEnum;
-        }
-
-        private bool IsNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
-        {
-            return keyToResolve.Name == null && keyToResolve.Type.IsGenericType && keyToResolve.Type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
-        }
-
-        private object GetPooledObject(RegistrationKey pooledObjectKey)
-        {
-            object obj;
-            if (GetObjectFromPool(pooledObjectKey, out obj))
-                return obj;
-
-            return null;
-        }
-
-        private bool GetObjectFromPool(RegistrationKey pooledObjectKey, out object obj)
-        {
-            if (!objectPool.TryGetValue(pooledObjectKey, out obj))
-                return false;
-
-            var nonDisposableWrapper = obj as NonDisposableWrapper;
-            if (nonDisposableWrapper != null)
-                obj = nonDisposableWrapper.Object;
-
-            return true;
-        }
-
-        private object ResolveObject(RegistrationKey keyToResolve, ResolutionList resolutionPath)
-        {
-            if (keyToResolve.Type.IsPrimitive || keyToResolve.Type == typeof(string) || keyToResolve.Type.IsValueType)
-                throw new ObjectContainerException("Primitive types or structs cannot be resolved: " + keyToResolve.Type.FullName, resolutionPath.ToTypeList());
-
-            var registrationResult = GetRegistrationResult(keyToResolve);
-            var isImplicitTypeRegistration = registrationResult == null;
-            var registrationToUse = registrationResult ??
-                new KeyValuePair<ObjectContainer, IRegistration>(this, new TypeRegistration(keyToResolve.Type));
-
-            var resolutionPathForResolve = registrationToUse.Key == this ? 
-                resolutionPath : new ResolutionList();
-            var result = registrationToUse.Value.Resolve(registrationToUse.Key, keyToResolve, resolutionPathForResolve);
-            if (isImplicitTypeRegistration) // upon successful implicit registration, we register the rule, so that sub context can also get the same resolved value
-                AddRegistration(keyToResolve, registrationToUse.Value);
-            return result;
-        }
-
-        private object CreateObject(Type type, ResolutionList resolutionPath, RegistrationKey keyToResolve)
-        {
-            var ctors = type.GetConstructors();
-            if (ctors.Length == 0)
-                ctors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Debug.Assert(ctors.Length > 0, "Class must have a constructor!");
-
-            int maxParamCount = ctors.Max(ctor => ctor.GetParameters().Length);
-            var maxParamCountCtors = ctors.Where(ctor => ctor.GetParameters().Length == maxParamCount).ToArray();
-
-            object obj;
-            if (maxParamCountCtors.Length == 1)
-            {
-                ConstructorInfo ctor = maxParamCountCtors[0];
-                if (resolutionPath.Contains(keyToResolve))
-                    throw new ObjectContainerException("Circular dependency found! " + type.FullName, resolutionPath.ToTypeList());
-
-                var args = ResolveArguments(ctor.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, type));
-                obj = ctor.Invoke(args);
-            }
-            else
-            {
-                throw new ObjectContainerException("Multiple public constructors with same maximum parameter count are not supported! " + type.FullName, resolutionPath.ToTypeList());
-            }
-
-            OnObjectCreated(obj);
-
-            return obj;
-        }
-
-        protected virtual void OnObjectCreated(object obj)
-        {
-            var eventHandler = ObjectCreated;
-            if (eventHandler != null)
-                eventHandler(obj);
-        }
-
-        private object InvokeFactoryDelegate(Delegate factoryDelegate, ResolutionList resolutionPath, RegistrationKey keyToResolve)
-        {
-            if (resolutionPath.Contains(keyToResolve))
-                throw new ObjectContainerException("Circular dependency found! " + factoryDelegate.ToString(), resolutionPath.ToTypeList());
-
-            var args = ResolveArguments(factoryDelegate.Method.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, null));
-            return factoryDelegate.DynamicInvoke(args);
-        }
-
-        private object[] ResolveArguments(IEnumerable<ParameterInfo> parameters, RegistrationKey keyToResolve, ResolutionList resolutionPath)
-        {
-            return parameters.Select(p => IsRegisteredNameParameter(p) ? ResolveRegisteredName(keyToResolve) : Resolve(p.ParameterType, resolutionPath, null)).ToArray();
-        }
-
-        private object ResolveRegisteredName(RegistrationKey keyToResolve)
-        {
-            return keyToResolve.Name;
-        }
-
-        private bool IsRegisteredNameParameter(ParameterInfo parameterInfo)
-        {
-            return parameterInfo.ParameterType == typeof (string) &&
-                   parameterInfo.Name.Equals(REGISTERED_NAME_PARAMETER_NAME);
         }
 
         #endregion
 
         public override string ToString()
         {
-            return string.Join(Environment.NewLine,
-                registrations
-                    .Where(r => !(r.Value is NamedInstanceDictionaryRegistration))
-                    .Select(r => string.Format("{0} -> {1}", r.Key, (r.Key.Type == typeof(IObjectContainer) && r.Key.Name == null) ? "<self>" : r.Value.ToString())));
-        }
-
-        private void AssertNotDisposed()
-        {
-            if (isDisposed)
-                throw new ObjectContainerException("Object container disposed", null);
+            lock (_syncLock)
+            {
+                return _unsafeContainer.ToString();
+            }
         }
 
         public void Dispose()
         {
-            isDisposed = true;
-
-            foreach (var obj in objectPool.Values.OfType<IDisposable>().Where(o => !ReferenceEquals(o, this)))
-                obj.Dispose();
-
-            objectPool.Clear();
-            registrations.Clear();
-            resolvedObjects.Clear();
+            lock (_syncLock)
+            {
+                _unsafeContainer.Dispose();
+            }
         }
     }
 


### PR DESCRIPTION
Hi,

I just wanted to share this code, which I developed for our company to solve issue https://github.com/techtalk/SpecFlow/issues/657 from Specflow, using NUnit runner along with an Unity 3 plugin.
This change to make the dependency injection thread-safe allowed us to parallellize at the feature level without any issue, while it was constantly failing before the fix.

Of course, the fix is pretty crude, as its aim was to have no public surface change, but I though it was better to share it if it could be of use.