### PR TITLE
[DO NOT MERGE] Poor main attempt to battle thread safety

### DIFF
--- a/BoDi.Tests/ParallelBoDiTests.cs
+++ b/BoDi.Tests/ParallelBoDiTests.cs
@@ -20,16 +20,20 @@ namespace BoDi.Tests
             public IObjectContainer Create(IObjectContainer parent = null) => new ObjectContainer(parent);
         }
 
-        private static IEnumerable<IObjectContainer> Create(IBodiFactory factory)
+        private static IObjectContainer[] Create(IBodiFactory factory)
         {
             var parent = factory.Create();
-            parent.RegisterTypeAs<object, object>();
+            parent.RegisterTypeAs<object, object>().InstancePerContext();
 
-            var left = factory.Create(parent);
-            var right = factory.Create(parent);
+            IEnumerable<IObjectContainer> CreateChilds(int count)
+            {
+                for (var i = 1; i < count; i ++)
+                {
+                    yield return factory.Create(parent);
+                }
+            }
 
-            yield return left;
-            yield return right;
+            return CreateChilds(50).ToArray();
         }
 
         [Test]
@@ -38,17 +42,25 @@ namespace BoDi.Tests
             var containers = Create(new BoDiSimpleFactory());
 
             var result = await Task.WhenAll(containers.Select(c => Task.Run(() => c.Resolve<object>())).ToArray());
-            Assert.AreSame(result[0], result[1]);
+            AssertResultsAreSame(result);
         }
 
-       
+        private static void AssertResultsAreSame(object[] result)
+        {
+            var first = result.First();
+            foreach (var any in result)
+            {
+                Assert.AreSame(first, any);
+            }
+        }
+
 
         [Test]
         public void ShouldWorkWhenCreateSequentally()
         {
             var containers = Create(new BoDiSimpleFactory());
             var result = containers.Select(c => c.Resolve<object>()).ToArray();
-            Assert.AreSame(result[0], result[1]);
+            AssertResultsAreSame(result);
         }
     }
 }

--- a/BoDi.Tests/ParallelBoDiTests.cs
+++ b/BoDi.Tests/ParallelBoDiTests.cs
@@ -1,0 +1,54 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BoDi.Tests
+{
+    [TestFixture]
+    public class ParallelBoDiTests
+    {
+        private interface IBodiFactory
+        {
+            IObjectContainer Create(IObjectContainer parent = null);
+
+        }
+        private class BoDiSimpleFactory : IBodiFactory
+        {
+            public IObjectContainer Create(IObjectContainer parent = null) => new ObjectContainer(parent);
+        }
+
+        private static IEnumerable<IObjectContainer> Create(IBodiFactory factory)
+        {
+            var parent = factory.Create();
+            parent.RegisterTypeAs<object, object>();
+
+            var left = factory.Create(parent);
+            var right = factory.Create(parent);
+
+            yield return left;
+            yield return right;
+        }
+
+        [Test]
+        public async Task ShouldWorkWhenCreateParallely()
+        {
+            var containers = Create(new BoDiSimpleFactory());
+
+            var result = await Task.WhenAll(containers.Select(c => Task.Run(() => c.Resolve<object>())).ToArray());
+            Assert.AreSame(result[0], result[1]);
+        }
+
+       
+
+        [Test]
+        public void ShouldWorkWhenCreateSequentally()
+        {
+            var containers = Create(new BoDiSimpleFactory());
+            var result = containers.Select(c => c.Resolve<object>()).ToArray();
+            Assert.AreSame(result[0], result[1]);
+        }
+    }
+}


### PR DESCRIPTION
Instead of approach in #24 (basically synchronize all access to `ObjectContainer`), i tried another approach.
Idea is to instead of container to synchronize access itself, it attempts synchronize access to parent container between other child containers. It not 100% solution (because those who use parent container directly will have to be careful to participate in synchronization, but in theory it will be more performant than #24 (because if you only one using container,  you don't need to pay for synchronization). I need to way to check if this is actually win for Specflow's usecase (may be not, cause Specflow use a long chain of containers).

I'm planning to benchmark every solution, but I have not settled on right profile.

This and #24 has a problem of holding the container-wide lock during construction of object. It could be very costly if your constructors are heavy. 