### PR TITLE
Make resolution thread-safe

### DIFF
--- a/BoDi.Performance.Tests/1.4/BoDi.cs
+++ b/BoDi.Performance.Tests/1.4/BoDi.cs
@@ -1,0 +1,1023 @@
+﻿/**************************************************************************************
+ * 
+ * BoDi: A very simple IoC container, easily embeddable also as a source code. 
+ * 
+ * BoDi was created to support SpecFlow (http://www.specflow.org) by Gaspar Nagy (http://gasparnagy.com/)
+ * 
+ * Project source & unit tests: http://github.com/gasparnagy/BoDi
+ * License: Apache License 2.0
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ * Change history
+ *   - New 'instance per dependency' strategy added for type and factory registrations (by MKMZ)
+ * 
+ * v1.4
+ *   - Provide .NET Standard 2.0 and .NET 4.5 library package (#14 by SabotageAndi)
+ *   - Fix: Collection was modified issue (#7)
+ *   - Exposing BaseContainer to the public interface (#17 by jessicabuttigieg)
+ *
+ * v1.3
+ *   - Fix: When an object resolved without registration using the concrete type it cannot be resolved from sub context
+ *   - Added IsRegistered methods to check if an interface or type is already registered (#6)
+ *   - Expose the ObjectContainer.RegisterFactoryAs in the IObjectContainer interface (by slawomir-brzezinski-at-interxion)
+ *   - eliminate internal TypeHelper class
+ *
+ * v1.2
+ *   - support for mapping of generic type definitions (by ibrahimbensalah)
+ *   - object should be created in the parent container, if the registration was applied there
+ *   - should be able to customize object creation with a container event (ObjectCreated)
+ *   - should be able to register factory delegates
+ *   - should be able to retrieve all named instance as a list with container.ResolveAll<T>()
+ *   - should not allow resolving value types (structs)
+ *   - should list registrations in container ToString()
+ *   - should not dispose registered instances by default, disposal can be requested by the 'dispose: true' parameter
+ *   - should be able to disable configuration file support (and the dependency on System.Configuration) with BODI_DISABLECONFIGFILESUPPORT compilation symbol
+ *   - smaller code refactoring
+ *   - improve resolution path handling
+ * 
+ * v1.1 - released with SpecFlow v1.9.0
+ * 
+ * 
+ * --------------
+ * Note about thread safety
+ * 
+ * BoDi container is not reentrant and can't be used from different threads.
+ * Typical user (Specflow) ensures it by allocating container per test thread and all feature- and scenario- containers as child containers.
+ * The manual synchronization is not necessary for usual cases 
+ * (using test-thread, feature or scenario containers and not creating multiple threads from the binding code).
+ * 
+ * More information here https://github.com/gasparnagy/BoDi/issues/27
+ */
+using System;
+using System.Collections;
+using System.Configuration;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace BoDi1_4
+{
+#if !BODI_LIMITEDRUNTIME
+    [Serializable]
+#endif
+    public class ObjectContainerException : Exception
+    {
+        public ObjectContainerException(string message, Type[] resolutionPath) : base(GetMessage(message, resolutionPath))
+        {
+        }
+
+#if !BODI_LIMITEDRUNTIME
+        protected ObjectContainerException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+#endif
+
+        static private string GetMessage(string message, Type[] resolutionPath)
+        {
+            if (resolutionPath == null || resolutionPath.Length == 0)
+                return message;
+
+            return string.Format("{0} (resolution path: {1})", message, string.Join("->", resolutionPath.Select(t => t.FullName).ToArray()));
+        }
+    }
+
+    public interface IObjectContainer: IDisposable
+    {
+        /// <summary>
+        /// Fired when a new object is created directly by the container. It is not invoked for resolving instance and factory registrations.
+        /// </summary>
+        event Action<object> ObjectCreated;
+
+        /// <summary>
+        /// Registers a type as the desired implementation type of an interface.
+        /// </summary>
+        /// <typeparam name="TType">Implementation type</typeparam>
+        /// <typeparam name="TInterface">Interface will be resolved</typeparam>
+        /// <returns>An object which allows to change resolving strategy.</returns>
+        /// <param name="name">A name to register named instance, otherwise null.</param>
+        /// <exception cref="ObjectContainerException">If there was already a resolve for the <typeparamref name="TInterface"/>.</exception>
+        /// <remarks>
+        ///     <para>Previous registrations can be overridden before the first resolution for the <typeparamref name="TInterface"/>.</para>
+        /// </remarks>
+        IStrategyRegistration RegisterTypeAs<TType, TInterface>(string name = null) where TType : class, TInterface;
+
+        /// <summary>
+        /// Registers an instance 
+        /// </summary>
+        /// <typeparam name="TInterface">Interface will be resolved</typeparam>
+        /// <param name="instance">The instance implements the interface.</param>
+        /// <param name="name">A name to register named instance, otherwise null.</param>
+        /// <param name="dispose">Whether the instance should be disposed on container dispose, otherwise <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="instance"/> is null.</exception>
+        /// <exception cref="ObjectContainerException">If there was already a resolve for the <typeparamref name="TInterface"/>.</exception>
+        /// <remarks>
+        ///     <para>Previous registrations can be overridden before the first resolution for the <typeparamref name="TInterface"/>.</para>
+        ///     <para>The instance will be registered in the object pool, so if a <see cref="Resolve{T}()"/> (for another interface) would require an instance of the dynamic type of the <paramref name="instance"/>, the <paramref name="instance"/> will be returned.</para>
+        /// </remarks>
+        void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false) where TInterface : class;
+
+        /// <summary>
+        /// Registers an instance 
+        /// </summary>
+        /// <param name="instance">The instance implements the interface.</param>
+        /// <param name="interfaceType">Interface will be resolved</param>
+        /// <param name="name">A name to register named instance, otherwise null.</param>
+        /// <param name="dispose">Whether the instance should be disposed on container dispose, otherwise <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="instance"/> is null.</exception>
+        /// <exception cref="ObjectContainerException">If there was already a resolve for the <paramref name="interfaceType"/>.</exception>
+        /// <remarks>
+        ///     <para>Previous registrations can be overridden before the first resolution for the <paramref name="interfaceType"/>.</para>
+        ///     <para>The instance will be registered in the object pool, so if a <see cref="Resolve{T}()"/> (for another interface) would require an instance of the dynamic type of the <paramref name="instance"/>, the <paramref name="instance"/> will be returned.</para>
+        /// </remarks>
+        void RegisterInstanceAs(object instance, Type interfaceType, string name = null, bool dispose = false);
+
+        /// <summary>
+        /// Registers an instance produced by <paramref name="factoryDelegate"/>. The delegate will be called only once and the instance it returned will be returned in each resolution.
+        /// </summary>
+        /// <typeparam name="TInterface">Interface to register as.</typeparam>
+        /// <param name="factoryDelegate">The function to run to obtain the instance.</param>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        IStrategyRegistration RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null);
+
+        /// <summary>
+        /// Resolves an implementation object for an interface or type.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
+        /// </remarks>
+        T Resolve<T>();
+
+        /// <summary>
+        /// Resolves an implementation object for an interface or type.
+        /// </summary>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
+        /// </remarks>
+        T Resolve<T>(string name);
+
+        /// <summary>
+        /// Resolves an implementation object for an interface or type.
+        /// </summary>
+        /// <param name="typeToResolve">The interface or type.</param>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        /// <returns>An object implementing <paramref name="typeToResolve"/>.</returns>
+        /// <remarks>
+        ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
+        /// </remarks>
+        object Resolve(Type typeToResolve, string name = null);
+
+        /// <summary>
+        /// Resolves all implementations of an interface or type.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        IEnumerable<T> ResolveAll<T>() where T : class;
+
+        /// <summary>
+        /// Determines whether the interface or type is registered.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns><c>true</c> if the interface or type is registered; otherwise <c>false</c>.</returns>
+        bool IsRegistered<T>();
+
+        /// <summary>
+        /// Determines whether the interface or type is registered with the specified name.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <param name="name">The name.</param>
+        /// <returns><c>true</c> if the interface or type is registered; otherwise <c>false</c>.</returns>
+        bool IsRegistered<T>(string name);
+    }
+    public interface IContainedInstance
+    {
+        IObjectContainer Container { get; }
+    }
+    public interface IStrategyRegistration
+    {
+        /// <summary>
+        /// Changes resolving strategy to a new instance per each dependency.
+        /// </summary>
+        /// <returns></returns>
+        IStrategyRegistration InstancePerDependency();
+        /// <summary>
+        /// Changes resolving strategy to a single instance per object container. This strategy is a default behaviour. 
+        /// </summary>
+        /// <returns></returns>
+        IStrategyRegistration InstancePerContext();
+    }
+
+    public class ObjectContainer : IObjectContainer
+    {
+        private const string REGISTERED_NAME_PARAMETER_NAME = "registeredName";
+
+        /// <summary>
+        /// A very simple immutable linked list of <see cref="Type"/>.
+        /// </summary>
+        private class ResolutionList
+        {
+            private readonly RegistrationKey currentRegistrationKey;
+            private readonly Type currentResolvedType;
+            private readonly ResolutionList nextNode;
+            private bool IsLast { get { return nextNode == null; } }
+
+            public ResolutionList()
+            {
+                Debug.Assert(IsLast);
+            }
+
+            private ResolutionList(RegistrationKey currentRegistrationKey, Type currentResolvedType, ResolutionList nextNode)
+            {
+                if (nextNode == null) throw new ArgumentNullException("nextNode");
+
+                this.currentRegistrationKey = currentRegistrationKey;
+                this.currentResolvedType = currentResolvedType;
+                this.nextNode = nextNode;
+            }
+
+            public ResolutionList AddToEnd(RegistrationKey registrationKey, Type resolvedType)
+            {
+                return new ResolutionList(registrationKey, resolvedType, this);
+            }
+
+            public bool Contains(Type resolvedType)
+            {
+                if (resolvedType == null) throw new ArgumentNullException("resolvedType");
+                return GetReverseEnumerable().Any(i => i.Value == resolvedType);
+            }
+
+            public bool Contains(RegistrationKey registrationKey)
+            {
+                return GetReverseEnumerable().Any(i => i.Key.Equals(registrationKey));
+            }
+
+            private IEnumerable<KeyValuePair<RegistrationKey, Type>> GetReverseEnumerable()
+            {
+                var node = this;
+                while (!node.IsLast)
+                {
+                    yield return new KeyValuePair<RegistrationKey, Type>(node.currentRegistrationKey, node.currentResolvedType);
+                    node = node.nextNode;
+                }
+            }
+
+            public Type[] ToTypeList()
+            {
+                return GetReverseEnumerable().Select(i => i.Value ?? i.Key.Type).Reverse().ToArray();
+            }
+
+            public override string ToString()
+            {
+                return string.Join(",", GetReverseEnumerable().Select(n => string.Format("{0}:{1}", n.Key, n.Value)));
+            }
+        }
+
+        private struct RegistrationKey
+        {
+            public readonly Type Type;
+            public readonly string Name;
+
+            public RegistrationKey(Type type, string name)
+            {
+                if (type == null) throw new ArgumentNullException("type");
+
+                Type = type;
+                Name = name;
+            }
+
+            private Type TypeGroup
+            {
+                get
+                {
+                    if (Type.IsGenericType && !Type.IsGenericTypeDefinition)
+                        return Type.GetGenericTypeDefinition();
+                    return Type;
+                }
+            }
+
+            public override string ToString()
+            {
+                Debug.Assert(Type.FullName != null);
+                if (Name == null)
+                    return Type.FullName;
+
+                return string.Format("{0}('{1}')", Type.FullName, Name);
+            }
+
+            bool Equals(RegistrationKey other)
+            {
+                var isInvertable = other.TypeGroup == Type || other.Type == TypeGroup || other.Type == Type;
+                return isInvertable && String.Equals(other.Name, Name, StringComparison.CurrentCultureIgnoreCase);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (obj.GetType() != typeof(RegistrationKey)) return false;
+                return Equals((RegistrationKey)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return TypeGroup.GetHashCode();
+                }
+            }
+        }
+
+        #region Registration types
+
+        private enum SolvingStrategy
+        {
+            PerContext,
+            PerDependency
+        }
+
+        private interface IRegistration
+        {
+            object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+        }
+
+        private class TypeRegistration : RegistrationWithStrategy, IRegistration
+        {
+            private readonly Type implementationType;
+
+            public TypeRegistration(Type implementationType)
+            {
+                this.implementationType = implementationType;
+            }
+
+            protected override object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var typeToConstruct = GetTypeToConstruct(keyToResolve);
+
+                var pooledObjectKey = new RegistrationKey(typeToConstruct, keyToResolve.Name);
+                object obj = container.GetPooledObject(pooledObjectKey);
+
+                if (obj == null)
+                {
+                    if (typeToConstruct.IsInterface)
+                        throw new ObjectContainerException("Interface cannot be resolved: " + keyToResolve, resolutionPath.ToTypeList());
+
+                    obj = container.CreateObject(typeToConstruct, resolutionPath, keyToResolve);
+                    container.objectPool.Add(pooledObjectKey, obj);
+                }
+
+                return obj;
+            }
+
+            protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var typeToConstruct = GetTypeToConstruct(keyToResolve);
+                if (typeToConstruct.IsInterface)
+                    throw new ObjectContainerException("Interface cannot be resolved: " + keyToResolve, resolutionPath.ToTypeList());
+                return container.CreateObject(typeToConstruct, resolutionPath, keyToResolve);
+            }
+
+            private Type GetTypeToConstruct(RegistrationKey keyToResolve)
+            {
+                var targetType = implementationType;
+                if (targetType.IsGenericTypeDefinition)
+                {
+                    var typeArgs = keyToResolve.Type.GetGenericArguments();
+                    targetType = targetType.MakeGenericType(typeArgs);
+                }
+                return targetType;
+            }
+
+            public override string ToString()
+            {
+                return "Type: " + implementationType.FullName;
+            }
+        }
+
+        private class InstanceRegistration : IRegistration
+        {
+            private readonly object instance;
+
+            public InstanceRegistration(object instance)
+            {
+                this.instance = instance;
+            }
+
+            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                return instance;
+            }
+
+            public override string ToString()
+            {
+                string instanceText;
+                try
+                {
+                    instanceText = instance.ToString();
+                }
+                catch (Exception ex)
+                {
+                    instanceText = ex.Message;
+                }
+
+                return "Instance: " + instanceText;
+            }
+        }
+
+        private abstract class RegistrationWithStrategy : IStrategyRegistration
+        {
+            protected SolvingStrategy solvingStrategy = SolvingStrategy.PerContext;
+            public virtual object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                if (solvingStrategy == SolvingStrategy.PerDependency)
+                {
+                    return ResolvePerDependency(container, keyToResolve, resolutionPath);
+                }
+                return ResolvePerContext(container, keyToResolve, resolutionPath);
+            }
+
+            protected abstract object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+            protected abstract object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+
+            public IStrategyRegistration InstancePerDependency()
+            {
+                solvingStrategy = SolvingStrategy.PerDependency;
+                return this;
+            }
+
+            public IStrategyRegistration InstancePerContext()
+            {
+                solvingStrategy = SolvingStrategy.PerContext;
+                return this;
+            }
+        }
+
+        private class FactoryRegistration : RegistrationWithStrategy, IRegistration
+        {
+            private readonly Delegate factoryDelegate;
+            public FactoryRegistration(Delegate factoryDelegate)
+            {
+                this.factoryDelegate = factoryDelegate;
+            }
+
+            protected override object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var obj = container.GetPooledObject(keyToResolve);
+                if (obj == null)
+                {
+                    obj = container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
+                    container.objectPool.Add(keyToResolve, obj);
+                }
+                return obj;
+            }
+            protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                return container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
+            }
+        }
+
+        private class NonDisposableWrapper
+        {
+            public object Object { get; private set; }
+
+            public NonDisposableWrapper(object obj)
+            {
+                Object = obj;
+            }
+        }
+
+        private class NamedInstanceDictionaryRegistration : IRegistration
+        {
+            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var typeToResolve = keyToResolve.Type;
+                Debug.Assert(typeToResolve.IsGenericType && typeToResolve.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+                var genericArguments = typeToResolve.GetGenericArguments();
+                var keyType = genericArguments[0];
+                var targetType = genericArguments[1];
+                var result = (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(genericArguments));
+
+                foreach (var namedRegistration in container.registrations.Where(r => r.Key.Name != null && r.Key.Type == targetType).Select(r => r.Key).ToList())
+                {
+                    var convertedKey = ChangeType(namedRegistration.Name, keyType);
+                    Debug.Assert(convertedKey != null);
+                    result.Add(convertedKey, container.Resolve(namedRegistration.Type, namedRegistration.Name));
+                }
+
+                return result;
+            }
+
+            private object ChangeType(string name, Type keyType)
+            {
+                if (keyType.IsEnum)
+                    return Enum.Parse(keyType, name, true);
+
+                Debug.Assert(keyType == typeof(string));
+                return name;
+            }
+        }
+
+        #endregion
+
+        private bool isDisposed = false;
+        private readonly ObjectContainer baseContainer;
+        private readonly Dictionary<RegistrationKey, IRegistration> registrations = new Dictionary<RegistrationKey, IRegistration>();
+        private readonly List<RegistrationKey> resolvedKeys = new List<RegistrationKey>();
+        private readonly Dictionary<RegistrationKey, object> objectPool = new Dictionary<RegistrationKey, object>();
+
+        public event Action<object> ObjectCreated;
+        public IObjectContainer BaseContainer => baseContainer;
+
+        public ObjectContainer(IObjectContainer baseContainer = null) 
+        {
+            if (baseContainer != null && !(baseContainer is ObjectContainer))
+                throw new ArgumentException("Base container must be an ObjectContainer", "baseContainer");
+
+            this.baseContainer = (ObjectContainer)baseContainer;
+            RegisterInstanceAs<IObjectContainer>(this);
+        }
+
+        #region Registration
+
+        public IStrategyRegistration RegisterTypeAs<TInterface>(Type implementationType, string name = null) where TInterface : class
+        {
+            Type interfaceType = typeof(TInterface);
+            return RegisterTypeAs(implementationType, interfaceType, name);
+        }
+
+        public IStrategyRegistration RegisterTypeAs<TType, TInterface>(string name = null) where TType : class, TInterface
+        {
+            Type interfaceType = typeof(TInterface);
+            Type implementationType = typeof(TType);
+            return RegisterTypeAs(implementationType, interfaceType, name);
+        }
+
+        public IStrategyRegistration RegisterTypeAs(Type implementationType, Type interfaceType)
+        {
+            if (!IsValidTypeMapping(implementationType, interfaceType))
+                throw new InvalidOperationException("type mapping is not valid");
+            return RegisterTypeAs(implementationType, interfaceType, null);
+        }
+
+        private bool IsValidTypeMapping(Type implementationType, Type interfaceType)
+        {
+            if (interfaceType.IsAssignableFrom(implementationType))
+                return true;
+
+            if (interfaceType.IsGenericTypeDefinition && implementationType.IsGenericTypeDefinition)
+            {
+                var baseTypes = GetBaseTypes(implementationType).ToArray();
+                return baseTypes.Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType);
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<Type> GetBaseTypes(Type type)
+        {
+            if (type.BaseType == null) return type.GetInterfaces();
+
+            return Enumerable.Repeat(type.BaseType, 1)
+                             .Concat(type.GetInterfaces())
+                             .Concat(type.GetInterfaces().SelectMany(GetBaseTypes))
+                             .Concat(GetBaseTypes(type.BaseType));
+        }
+
+
+        private RegistrationKey CreateNamedInstanceDictionaryKey(Type targetType)
+        {
+            return new RegistrationKey(typeof(IDictionary<,>).MakeGenericType(typeof(string), targetType), null);
+        }
+
+        private void AddRegistration(RegistrationKey key, IRegistration registration)
+        {
+            registrations[key] = registration;
+
+            if (key.Name != null)
+            {
+                var dictKey = CreateNamedInstanceDictionaryKey(key.Type);
+                if (!registrations.ContainsKey(dictKey))
+                {
+                    registrations[dictKey] = new NamedInstanceDictionaryRegistration();
+                }
+            }
+        }
+
+        private IStrategyRegistration RegisterTypeAs(Type implementationType, Type interfaceType, string name)
+        {
+            var registrationKey = new RegistrationKey(interfaceType, name);
+            AssertNotResolved(registrationKey);
+
+            ClearRegistrations(registrationKey);
+            var typeRegistration = new TypeRegistration(implementationType);
+            AddRegistration(registrationKey, typeRegistration);
+
+            return typeRegistration;
+        }
+
+        public void RegisterInstanceAs(object instance, Type interfaceType, string name = null, bool dispose = false)
+        {
+            if (instance == null)
+                throw new ArgumentNullException("instance");
+            var registrationKey = new RegistrationKey(interfaceType, name);
+            AssertNotResolved(registrationKey);
+
+            ClearRegistrations(registrationKey);
+            AddRegistration(registrationKey, new InstanceRegistration(instance));
+            objectPool[new RegistrationKey(instance.GetType(), name)] = GetPoolableInstance(instance, dispose);
+        }
+
+        private static object GetPoolableInstance(object instance, bool dispose)
+        {
+            return (instance is IDisposable) && !dispose ? new NonDisposableWrapper(instance) : instance;
+        }
+
+        public void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false) where TInterface : class
+        {
+            RegisterInstanceAs(instance, typeof(TInterface), name, dispose);
+        }
+
+        public IStrategyRegistration RegisterFactoryAs<TInterface>(Func<TInterface> factoryDelegate, string name = null)
+        {
+            return RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+        }
+
+        public IStrategyRegistration RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null)
+        {
+            return RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+        }
+
+        public void RegisterFactoryAs<TInterface>(Delegate factoryDelegate, string name = null)
+        {
+            RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+        }
+
+        public IStrategyRegistration RegisterFactoryAs(Delegate factoryDelegate, Type interfaceType, string name = null)
+        {
+            if (factoryDelegate == null) throw new ArgumentNullException("factoryDelegate");
+            if (interfaceType == null) throw new ArgumentNullException("interfaceType");
+
+            var registrationKey = new RegistrationKey(interfaceType, name);
+            AssertNotResolved(registrationKey);
+
+            ClearRegistrations(registrationKey);
+            var factoryRegistration = new FactoryRegistration(factoryDelegate);
+            AddRegistration(registrationKey, factoryRegistration);
+
+            return factoryRegistration;
+        }
+
+        public bool IsRegistered<T>()
+        {
+            return this.IsRegistered<T>(null);
+        }
+
+        public bool IsRegistered<T>(string name)
+        {
+            Type typeToResolve = typeof(T);
+
+            var keyToResolve = new RegistrationKey(typeToResolve, name);
+
+            return registrations.ContainsKey(keyToResolve);
+        }
+
+        // ReSharper disable once UnusedParameter.Local
+        private void AssertNotResolved(RegistrationKey interfaceType)
+        {
+            if (resolvedKeys.Contains(interfaceType))
+                throw new ObjectContainerException("An object has been resolved for this interface already.", null);
+        }
+
+        private void ClearRegistrations(RegistrationKey registrationKey)
+        {
+            registrations.Remove(registrationKey);
+        }
+
+#if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT
+        public void RegisterFromConfiguration()
+        {
+            var section = (BoDiConfigurationSection)ConfigurationManager.GetSection("boDi");
+            if (section == null)
+                return;
+
+            RegisterFromConfiguration(section.Registrations);
+        }
+
+        public void RegisterFromConfiguration(ContainerRegistrationCollection containerRegistrationCollection)
+        {
+            if (containerRegistrationCollection == null)
+                return;
+
+            foreach (ContainerRegistrationConfigElement registrationConfigElement in containerRegistrationCollection)
+            {
+                RegisterFromConfiguration(registrationConfigElement);
+            }
+        }
+
+        private void RegisterFromConfiguration(ContainerRegistrationConfigElement registrationConfigElement)
+        {
+            Type interfaceType = Type.GetType(registrationConfigElement.Interface, true);
+            Type implementationType = Type.GetType(registrationConfigElement.Implementation, true);
+
+            RegisterTypeAs(implementationType, interfaceType, string.IsNullOrEmpty(registrationConfigElement.Name) ? null : registrationConfigElement.Name);
+        }
+#endif
+
+        #endregion
+
+        #region Resolve
+
+        public T Resolve<T>()
+        {
+            return Resolve<T>(null);
+        }
+
+        public T Resolve<T>(string name)
+        {
+            Type typeToResolve = typeof(T);
+
+            object resolvedObject = Resolve(typeToResolve, name);
+
+            return (T)resolvedObject;
+        }
+
+        public object Resolve(Type typeToResolve, string name = null)
+        {
+            return Resolve(typeToResolve, new ResolutionList(), name);
+        }
+
+        public IEnumerable<T> ResolveAll<T>() where T : class
+        {
+            return registrations
+                .Where(x => x.Key.Type == typeof(T))
+                .Select(x => Resolve (x.Key.Type, x.Key.Name) as T);
+        }
+
+        private object Resolve(Type typeToResolve, ResolutionList resolutionPath, string name)
+        {
+            AssertNotDisposed();
+
+            var keyToResolve = new RegistrationKey(typeToResolve, name);
+            object resolvedObject = ResolveObject(keyToResolve, resolutionPath);
+            if (!resolvedKeys.Contains(keyToResolve))
+            {
+                resolvedKeys.Add(keyToResolve);
+            }
+            Debug.Assert(typeToResolve.IsInstanceOfType(resolvedObject));
+            return resolvedObject;
+        }
+
+        private KeyValuePair<ObjectContainer, IRegistration>? GetRegistrationResult(RegistrationKey keyToResolve)
+        {
+            IRegistration registration;
+            if (registrations.TryGetValue(keyToResolve, out registration))
+            {
+                return new KeyValuePair<ObjectContainer, IRegistration>(this, registration);
+            }
+
+            if (baseContainer != null)
+                return baseContainer.GetRegistrationResult(keyToResolve);
+
+            if (IsSpecialNamedInstanceDictionaryKey(keyToResolve))
+            {
+                var targetType = keyToResolve.Type.GetGenericArguments()[1];
+                return GetRegistrationResult(CreateNamedInstanceDictionaryKey(targetType));
+            }
+
+            // if there was no named registration, we still return an empty dictionary
+            if (IsDefaultNamedInstanceDictionaryKey(keyToResolve))
+            {
+                return new KeyValuePair<ObjectContainer, IRegistration>(this, new NamedInstanceDictionaryRegistration());
+            }
+
+            return null;
+        }
+
+        private bool IsDefaultNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+        {
+            return IsNamedInstanceDictionaryKey(keyToResolve) && 
+                   keyToResolve.Type.GetGenericArguments()[0] == typeof(string);
+        }
+
+        private bool IsSpecialNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+        {
+            return IsNamedInstanceDictionaryKey(keyToResolve) && 
+                   keyToResolve.Type.GetGenericArguments()[0].IsEnum;
+        }
+
+        private bool IsNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+        {
+            return keyToResolve.Name == null && keyToResolve.Type.IsGenericType && keyToResolve.Type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
+        }
+
+        private object GetPooledObject(RegistrationKey pooledObjectKey)
+        {
+            object obj;
+            if (GetObjectFromPool(pooledObjectKey, out obj))
+                return obj;
+
+            return null;
+        }
+
+        private bool GetObjectFromPool(RegistrationKey pooledObjectKey, out object obj)
+        {
+            if (!objectPool.TryGetValue(pooledObjectKey, out obj))
+                return false;
+
+            var nonDisposableWrapper = obj as NonDisposableWrapper;
+            if (nonDisposableWrapper != null)
+                obj = nonDisposableWrapper.Object;
+
+            return true;
+        }
+
+        private object ResolveObject(RegistrationKey keyToResolve, ResolutionList resolutionPath)
+        {
+            if (keyToResolve.Type.IsPrimitive || keyToResolve.Type == typeof(string) || keyToResolve.Type.IsValueType)
+                throw new ObjectContainerException("Primitive types or structs cannot be resolved: " + keyToResolve.Type.FullName, resolutionPath.ToTypeList());
+
+            var registrationResult = GetRegistrationResult(keyToResolve);
+            var isImplicitTypeRegistration = registrationResult == null;
+            var registrationToUse = registrationResult ??
+                new KeyValuePair<ObjectContainer, IRegistration>(this, new TypeRegistration(keyToResolve.Type));
+
+            var resolutionPathForResolve = registrationToUse.Key == this ? 
+                resolutionPath : new ResolutionList();
+            var result = registrationToUse.Value.Resolve(registrationToUse.Key, keyToResolve, resolutionPathForResolve);
+            if (isImplicitTypeRegistration) // upon successful implicit registration, we register the rule, so that sub context can also get the same resolved value
+                AddRegistration(keyToResolve, registrationToUse.Value);
+            return result;
+        }
+
+        private object CreateObject(Type type, ResolutionList resolutionPath, RegistrationKey keyToResolve)
+        {
+            var ctors = type.GetConstructors();
+            if (ctors.Length == 0)
+                ctors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Debug.Assert(ctors.Length > 0, "Class must have a constructor!");
+
+            int maxParamCount = ctors.Max(ctor => ctor.GetParameters().Length);
+            var maxParamCountCtors = ctors.Where(ctor => ctor.GetParameters().Length == maxParamCount).ToArray();
+
+            object obj;
+            if (maxParamCountCtors.Length == 1)
+            {
+                ConstructorInfo ctor = maxParamCountCtors[0];
+                if (resolutionPath.Contains(keyToResolve))
+                    throw new ObjectContainerException("Circular dependency found! " + type.FullName, resolutionPath.ToTypeList());
+
+                var args = ResolveArguments(ctor.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, type));
+                obj = ctor.Invoke(args);
+            }
+            else
+            {
+                throw new ObjectContainerException("Multiple public constructors with same maximum parameter count are not supported! " + type.FullName, resolutionPath.ToTypeList());
+            }
+
+            OnObjectCreated(obj);
+
+            return obj;
+        }
+
+        protected virtual void OnObjectCreated(object obj)
+        {
+            var eventHandler = ObjectCreated;
+            if (eventHandler != null)
+                eventHandler(obj);
+        }
+
+        private object InvokeFactoryDelegate(Delegate factoryDelegate, ResolutionList resolutionPath, RegistrationKey keyToResolve)
+        {
+            if (resolutionPath.Contains(keyToResolve))
+                throw new ObjectContainerException("Circular dependency found! " + factoryDelegate.ToString(), resolutionPath.ToTypeList());
+
+            var args = ResolveArguments(factoryDelegate.Method.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, null));
+            return factoryDelegate.DynamicInvoke(args);
+        }
+
+        private object[] ResolveArguments(IEnumerable<ParameterInfo> parameters, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+        {
+            return parameters.Select(p => IsRegisteredNameParameter(p) ? ResolveRegisteredName(keyToResolve) : Resolve(p.ParameterType, resolutionPath, null)).ToArray();
+        }
+
+        private object ResolveRegisteredName(RegistrationKey keyToResolve)
+        {
+            return keyToResolve.Name;
+        }
+
+        private bool IsRegisteredNameParameter(ParameterInfo parameterInfo)
+        {
+            return parameterInfo.ParameterType == typeof (string) &&
+                   parameterInfo.Name.Equals(REGISTERED_NAME_PARAMETER_NAME);
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            return string.Join(Environment.NewLine,
+                registrations
+                    .Where(r => !(r.Value is NamedInstanceDictionaryRegistration))
+                    .Select(r => string.Format("{0} -> {1}", r.Key, (r.Key.Type == typeof(IObjectContainer) && r.Key.Name == null) ? "<self>" : r.Value.ToString())));
+        }
+
+        private void AssertNotDisposed()
+        {
+            if (isDisposed)
+                throw new ObjectContainerException("Object container disposed", null);
+        }
+
+        public void Dispose()
+        {
+            isDisposed = true;
+
+            foreach (var obj in objectPool.Values.OfType<IDisposable>().Where(o => !ReferenceEquals(o, this)))
+                obj.Dispose();
+
+            objectPool.Clear();
+            registrations.Clear();
+            resolvedKeys.Clear();
+        }
+    }
+
+    #region Configuration handling
+#if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT
+
+    public class BoDiConfigurationSection : ConfigurationSection
+    {
+        [ConfigurationProperty("", Options = ConfigurationPropertyOptions.IsDefaultCollection)]
+        [ConfigurationCollection(typeof(ContainerRegistrationCollection), AddItemName = "register")]
+        public ContainerRegistrationCollection Registrations
+        {
+            get { return (ContainerRegistrationCollection)this[""]; }
+            set { this[""] = value; }
+        }
+    }
+
+    public class ContainerRegistrationCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new ContainerRegistrationConfigElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            var registrationConfigElement = ((ContainerRegistrationConfigElement)element);
+            string elementKey = registrationConfigElement.Interface;
+            if (registrationConfigElement.Name != null)
+                elementKey = elementKey + "/" + registrationConfigElement.Name;
+            return elementKey;
+        }
+
+        public void Add(string implementationType, string interfaceType, string name = null)
+        {
+            BaseAdd(new ContainerRegistrationConfigElement
+                        {
+                            Implementation = implementationType,
+                            Interface = interfaceType,
+                            Name = name
+                        });
+        }
+    }
+
+    public class ContainerRegistrationConfigElement : ConfigurationElement
+    {
+        [ConfigurationProperty("as", IsRequired = true)]
+        public string Interface
+        {
+            get { return (string)this["as"]; }
+            set { this["as"] = value; }
+        }
+
+        [ConfigurationProperty("type", IsRequired = true)]
+        public string Implementation
+        {
+            get { return (string)this["type"]; }
+            set { this["type"] = value; }
+        }
+
+        [ConfigurationProperty("name", IsRequired = false, DefaultValue = null)]
+        public string Name
+        {
+            get { return (string)this["name"]; }
+            set { this["name"] = value; }
+        }
+    }
+
+#endif
+    #endregion
+}

--- a/BoDi.Performance.Tests/1.next-flawed/BoDi.cs
+++ b/BoDi.Performance.Tests/1.next-flawed/BoDi.cs
@@ -1,0 +1,1034 @@
+﻿/**************************************************************************************
+ * 
+ * BoDi: A very simple IoC container, easily embeddable also as a source code. 
+ * 
+ * BoDi was created to support SpecFlow (http://www.specflow.org) by Gaspar Nagy (http://gasparnagy.com/)
+ * 
+ * Project source & unit tests: http://github.com/gasparnagy/BoDi
+ * License: Apache License 2.0
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ * Change history
+ *   - New 'instance per dependency' strategy added for type and factory registrations (by MKMZ)
+ * 
+ * v1.4
+ *   - Provide .NET Standard 2.0 and .NET 4.5 library package (#14 by SabotageAndi)
+ *   - Fix: Collection was modified issue (#7)
+ *   - Exposing BaseContainer to the public interface (#17 by jessicabuttigieg)
+ *
+ * v1.3
+ *   - Fix: When an object resolved without registration using the concrete type it cannot be resolved from sub context
+ *   - Added IsRegistered methods to check if an interface or type is already registered (#6)
+ *   - Expose the ObjectContainer.RegisterFactoryAs in the IObjectContainer interface (by slawomir-brzezinski-at-interxion)
+ *   - eliminate internal TypeHelper class
+ *
+ * v1.2
+ *   - support for mapping of generic type definitions (by ibrahimbensalah)
+ *   - object should be created in the parent container, if the registration was applied there
+ *   - should be able to customize object creation with a container event (ObjectCreated)
+ *   - should be able to register factory delegates
+ *   - should be able to retrieve all named instance as a list with container.ResolveAll<T>()
+ *   - should not allow resolving value types (structs)
+ *   - should list registrations in container ToString()
+ *   - should not dispose registered instances by default, disposal can be requested by the 'dispose: true' parameter
+ *   - should be able to disable configuration file support (and the dependency on System.Configuration) with BODI_DISABLECONFIGFILESUPPORT compilation symbol
+ *   - smaller code refactoring
+ *   - improve resolution path handling
+ * 
+ * v1.1 - released with SpecFlow v1.9.0
+ * 
+ * 
+ * --------------
+ * Note about thread safety
+ * 
+ * BoDi container is not reentrant and can't be used from different threads.
+ * Typical user (Specflow) ensures it by allocating container per test thread and all feature- and scenario- containers as child containers.
+ * The manual synchronization is not necessary for usual cases 
+ * (using test-thread, feature or scenario containers and not creating multiple threads from the binding code).
+ * 
+ * More information here https://github.com/gasparnagy/BoDi/issues/27
+ */
+using System;
+using System.Collections;
+using System.Configuration;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace BoDi1_Next_Flawed
+{
+#if !BODI_LIMITEDRUNTIME
+    [Serializable]
+#endif
+    public class ObjectContainerException : Exception
+    {
+        public ObjectContainerException(string message, Type[] resolutionPath) : base(GetMessage(message, resolutionPath))
+        {
+        }
+
+#if !BODI_LIMITEDRUNTIME
+        protected ObjectContainerException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+#endif
+
+        static private string GetMessage(string message, Type[] resolutionPath)
+        {
+            if (resolutionPath == null || resolutionPath.Length == 0)
+                return message;
+
+            return string.Format("{0} (resolution path: {1})", message, string.Join("->", resolutionPath.Select(t => t.FullName).ToArray()));
+        }
+    }
+
+    public interface IObjectContainer: IDisposable
+    {
+        /// <summary>
+        /// Fired when a new object is created directly by the container. It is not invoked for resolving instance and factory registrations.
+        /// </summary>
+        event Action<object> ObjectCreated;
+
+        /// <summary>
+        /// Registers a type as the desired implementation type of an interface.
+        /// </summary>
+        /// <typeparam name="TType">Implementation type</typeparam>
+        /// <typeparam name="TInterface">Interface will be resolved</typeparam>
+        /// <returns>An object which allows to change resolving strategy.</returns>
+        /// <param name="name">A name to register named instance, otherwise null.</param>
+        /// <exception cref="ObjectContainerException">If there was already a resolve for the <typeparamref name="TInterface"/>.</exception>
+        /// <remarks>
+        ///     <para>Previous registrations can be overridden before the first resolution for the <typeparamref name="TInterface"/>.</para>
+        /// </remarks>
+        IStrategyRegistration RegisterTypeAs<TType, TInterface>(string name = null) where TType : class, TInterface;
+
+        /// <summary>
+        /// Registers an instance 
+        /// </summary>
+        /// <typeparam name="TInterface">Interface will be resolved</typeparam>
+        /// <param name="instance">The instance implements the interface.</param>
+        /// <param name="name">A name to register named instance, otherwise null.</param>
+        /// <param name="dispose">Whether the instance should be disposed on container dispose, otherwise <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="instance"/> is null.</exception>
+        /// <exception cref="ObjectContainerException">If there was already a resolve for the <typeparamref name="TInterface"/>.</exception>
+        /// <remarks>
+        ///     <para>Previous registrations can be overridden before the first resolution for the <typeparamref name="TInterface"/>.</para>
+        ///     <para>The instance will be registered in the object pool, so if a <see cref="Resolve{T}()"/> (for another interface) would require an instance of the dynamic type of the <paramref name="instance"/>, the <paramref name="instance"/> will be returned.</para>
+        /// </remarks>
+        void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false) where TInterface : class;
+
+        /// <summary>
+        /// Registers an instance 
+        /// </summary>
+        /// <param name="instance">The instance implements the interface.</param>
+        /// <param name="interfaceType">Interface will be resolved</param>
+        /// <param name="name">A name to register named instance, otherwise null.</param>
+        /// <param name="dispose">Whether the instance should be disposed on container dispose, otherwise <c>false</c>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="instance"/> is null.</exception>
+        /// <exception cref="ObjectContainerException">If there was already a resolve for the <paramref name="interfaceType"/>.</exception>
+        /// <remarks>
+        ///     <para>Previous registrations can be overridden before the first resolution for the <paramref name="interfaceType"/>.</para>
+        ///     <para>The instance will be registered in the object pool, so if a <see cref="Resolve{T}()"/> (for another interface) would require an instance of the dynamic type of the <paramref name="instance"/>, the <paramref name="instance"/> will be returned.</para>
+        /// </remarks>
+        void RegisterInstanceAs(object instance, Type interfaceType, string name = null, bool dispose = false);
+
+        /// <summary>
+        /// Registers an instance produced by <paramref name="factoryDelegate"/>. The delegate will be called only once and the instance it returned will be returned in each resolution.
+        /// </summary>
+        /// <typeparam name="TInterface">Interface to register as.</typeparam>
+        /// <param name="factoryDelegate">The function to run to obtain the instance.</param>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        IStrategyRegistration RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null);
+
+        /// <summary>
+        /// Resolves an implementation object for an interface or type.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
+        /// </remarks>
+        T Resolve<T>();
+
+        /// <summary>
+        /// Resolves an implementation object for an interface or type.
+        /// </summary>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
+        /// </remarks>
+        T Resolve<T>(string name);
+
+        /// <summary>
+        /// Resolves an implementation object for an interface or type.
+        /// </summary>
+        /// <param name="typeToResolve">The interface or type.</param>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        /// <returns>An object implementing <paramref name="typeToResolve"/>.</returns>
+        /// <remarks>
+        ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
+        /// </remarks>
+        object Resolve(Type typeToResolve, string name = null);
+
+        /// <summary>
+        /// Resolves all implementations of an interface or type.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        IEnumerable<T> ResolveAll<T>() where T : class;
+
+        /// <summary>
+        /// Determines whether the interface or type is registered.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns><c>true</c> if the interface or type is registered; otherwise <c>false</c>.</returns>
+        bool IsRegistered<T>();
+
+        /// <summary>
+        /// Determines whether the interface or type is registered with the specified name.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <param name="name">The name.</param>
+        /// <returns><c>true</c> if the interface or type is registered; otherwise <c>false</c>.</returns>
+        bool IsRegistered<T>(string name);
+    }
+    public interface IContainedInstance
+    {
+        IObjectContainer Container { get; }
+    }
+    public interface IStrategyRegistration
+    {
+        /// <summary>
+        /// Changes resolving strategy to a new instance per each dependency.
+        /// </summary>
+        /// <returns></returns>
+        IStrategyRegistration InstancePerDependency();
+        /// <summary>
+        /// Changes resolving strategy to a single instance per object container. This strategy is a default behaviour. 
+        /// </summary>
+        /// <returns></returns>
+        IStrategyRegistration InstancePerContext();
+    }
+
+    public class ObjectContainer : IObjectContainer
+    {
+        private const string REGISTERED_NAME_PARAMETER_NAME = "registeredName";
+
+        /// <summary>
+        /// A very simple immutable linked list of <see cref="Type"/>.
+        /// </summary>
+        private class ResolutionList
+        {
+            private readonly RegistrationKey currentRegistrationKey;
+            private readonly Type currentResolvedType;
+            private readonly ResolutionList nextNode;
+            private bool IsLast { get { return nextNode == null; } }
+
+            public ResolutionList()
+            {
+                Debug.Assert(IsLast);
+            }
+
+            private ResolutionList(RegistrationKey currentRegistrationKey, Type currentResolvedType, ResolutionList nextNode)
+            {
+                if (nextNode == null) throw new ArgumentNullException("nextNode");
+
+                this.currentRegistrationKey = currentRegistrationKey;
+                this.currentResolvedType = currentResolvedType;
+                this.nextNode = nextNode;
+            }
+
+            public ResolutionList AddToEnd(RegistrationKey registrationKey, Type resolvedType)
+            {
+                return new ResolutionList(registrationKey, resolvedType, this);
+            }
+
+            public bool Contains(Type resolvedType)
+            {
+                if (resolvedType == null) throw new ArgumentNullException("resolvedType");
+                return GetReverseEnumerable().Any(i => i.Value == resolvedType);
+            }
+
+            public bool Contains(RegistrationKey registrationKey)
+            {
+                return GetReverseEnumerable().Any(i => i.Key.Equals(registrationKey));
+            }
+
+            private IEnumerable<KeyValuePair<RegistrationKey, Type>> GetReverseEnumerable()
+            {
+                var node = this;
+                while (!node.IsLast)
+                {
+                    yield return new KeyValuePair<RegistrationKey, Type>(node.currentRegistrationKey, node.currentResolvedType);
+                    node = node.nextNode;
+                }
+            }
+
+            public Type[] ToTypeList()
+            {
+                return GetReverseEnumerable().Select(i => i.Value ?? i.Key.Type).Reverse().ToArray();
+            }
+
+            public override string ToString()
+            {
+                return string.Join(",", GetReverseEnumerable().Select(n => string.Format("{0}:{1}", n.Key, n.Value)));
+            }
+        }
+
+        private struct RegistrationKey
+        {
+            public readonly Type Type;
+            public readonly string Name;
+
+            public RegistrationKey(Type type, string name)
+            {
+                if (type == null) throw new ArgumentNullException("type");
+
+                Type = type;
+                Name = name;
+            }
+
+            private Type TypeGroup
+            {
+                get
+                {
+                    if (Type.IsGenericType && !Type.IsGenericTypeDefinition)
+                        return Type.GetGenericTypeDefinition();
+                    return Type;
+                }
+            }
+
+            public override string ToString()
+            {
+                Debug.Assert(Type.FullName != null);
+                if (Name == null)
+                    return Type.FullName;
+
+                return string.Format("{0}('{1}')", Type.FullName, Name);
+            }
+
+            bool Equals(RegistrationKey other)
+            {
+                var isInvertable = other.TypeGroup == Type || other.Type == TypeGroup || other.Type == Type;
+                return isInvertable && String.Equals(other.Name, Name, StringComparison.CurrentCultureIgnoreCase);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (obj.GetType() != typeof(RegistrationKey)) return false;
+                return Equals((RegistrationKey)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return TypeGroup.GetHashCode();
+                }
+            }
+        }
+
+        #region Registration types
+
+        private enum SolvingStrategy
+        {
+            PerContext,
+            PerDependency
+        }
+
+        private interface IRegistration
+        {
+            object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+        }
+
+        private class TypeRegistration : RegistrationWithStrategy, IRegistration
+        {
+            private readonly Type implementationType;
+
+            public TypeRegistration(Type implementationType)
+            {
+                this.implementationType = implementationType;
+            }
+
+            protected override object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var typeToConstruct = GetTypeToConstruct(keyToResolve);
+
+                var pooledObjectKey = new RegistrationKey(typeToConstruct, keyToResolve.Name);
+                object obj = container.GetPooledObject(pooledObjectKey);
+
+                if (obj == null)
+                {
+                    if (typeToConstruct.IsInterface)
+                        throw new ObjectContainerException("Interface cannot be resolved: " + keyToResolve, resolutionPath.ToTypeList());
+
+                    obj = container.CreateObject(typeToConstruct, resolutionPath, keyToResolve);
+                    container.objectPool.Add(pooledObjectKey, obj);
+                }
+
+                return obj;
+            }
+
+            protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var typeToConstruct = GetTypeToConstruct(keyToResolve);
+                if (typeToConstruct.IsInterface)
+                    throw new ObjectContainerException("Interface cannot be resolved: " + keyToResolve, resolutionPath.ToTypeList());
+                return container.CreateObject(typeToConstruct, resolutionPath, keyToResolve);
+            }
+
+            private Type GetTypeToConstruct(RegistrationKey keyToResolve)
+            {
+                var targetType = implementationType;
+                if (targetType.IsGenericTypeDefinition)
+                {
+                    var typeArgs = keyToResolve.Type.GetGenericArguments();
+                    targetType = targetType.MakeGenericType(typeArgs);
+                }
+                return targetType;
+            }
+
+            public override string ToString()
+            {
+                return "Type: " + implementationType.FullName;
+            }
+        }
+
+        private class InstanceRegistration : IRegistration
+        {
+            private readonly object instance;
+
+            public InstanceRegistration(object instance)
+            {
+                this.instance = instance;
+            }
+
+            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                return instance;
+            }
+
+            public override string ToString()
+            {
+                string instanceText;
+                try
+                {
+                    instanceText = instance.ToString();
+                }
+                catch (Exception ex)
+                {
+                    instanceText = ex.Message;
+                }
+
+                return "Instance: " + instanceText;
+            }
+        }
+
+        private abstract class RegistrationWithStrategy : IStrategyRegistration
+        {
+            protected SolvingStrategy solvingStrategy = SolvingStrategy.PerContext;
+            public virtual object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                if (solvingStrategy == SolvingStrategy.PerDependency)
+                {
+                    return ResolvePerDependency(container, keyToResolve, resolutionPath);
+                }
+                return ResolvePerContext(container, keyToResolve, resolutionPath);
+            }
+
+            protected abstract object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+            protected abstract object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+
+            public IStrategyRegistration InstancePerDependency()
+            {
+                solvingStrategy = SolvingStrategy.PerDependency;
+                return this;
+            }
+
+            public IStrategyRegistration InstancePerContext()
+            {
+                solvingStrategy = SolvingStrategy.PerContext;
+                return this;
+            }
+        }
+
+        private class FactoryRegistration : RegistrationWithStrategy, IRegistration
+        {
+            private readonly Delegate factoryDelegate;
+            public FactoryRegistration(Delegate factoryDelegate)
+            {
+                this.factoryDelegate = factoryDelegate;
+            }
+
+            protected override object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var obj = container.GetPooledObject(keyToResolve);
+                if (obj == null)
+                {
+                    obj = container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
+                    container.objectPool.Add(keyToResolve, obj);
+                }
+                return obj;
+            }
+            protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                return container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
+            }
+        }
+
+        private class NonDisposableWrapper
+        {
+            public object Object { get; private set; }
+
+            public NonDisposableWrapper(object obj)
+            {
+                Object = obj;
+            }
+        }
+
+        private class NamedInstanceDictionaryRegistration : IRegistration
+        {
+            public object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            {
+                var typeToResolve = keyToResolve.Type;
+                Debug.Assert(typeToResolve.IsGenericType && typeToResolve.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+                var genericArguments = typeToResolve.GetGenericArguments();
+                var keyType = genericArguments[0];
+                var targetType = genericArguments[1];
+                var result = (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(genericArguments));
+
+                foreach (var namedRegistration in container.registrations.Where(r => r.Key.Name != null && r.Key.Type == targetType).Select(r => r.Key).ToList())
+                {
+                    var convertedKey = ChangeType(namedRegistration.Name, keyType);
+                    Debug.Assert(convertedKey != null);
+                    result.Add(convertedKey, container.ResolveInternal(namedRegistration.Type, new ResolutionList(), namedRegistration.Name));
+                }
+
+                return result;
+            }
+
+            private object ChangeType(string name, Type keyType)
+            {
+                if (keyType.IsEnum)
+                    return Enum.Parse(keyType, name, true);
+
+                Debug.Assert(keyType == typeof(string));
+                return name;
+            }
+        }
+
+        #endregion
+
+        private bool isDisposed = false;
+        private readonly ObjectContainer baseContainer;
+        private readonly Dictionary<RegistrationKey, IRegistration> registrations = new Dictionary<RegistrationKey, IRegistration>();
+        private readonly List<RegistrationKey> resolvedKeys = new List<RegistrationKey>();
+        private readonly Dictionary<RegistrationKey, object> objectPool = new Dictionary<RegistrationKey, object>();
+
+        public event Action<object> ObjectCreated;
+        public IObjectContainer BaseContainer => baseContainer;
+
+        public ObjectContainer(IObjectContainer baseContainer = null) 
+        {
+            if (baseContainer != null && !(baseContainer is ObjectContainer))
+                throw new ArgumentException("Base container must be an ObjectContainer", "baseContainer");
+
+            this.baseContainer = (ObjectContainer)baseContainer;
+            RegisterInstanceAs<IObjectContainer>(this);
+        }
+
+        #region Registration
+
+        public IStrategyRegistration RegisterTypeAs<TInterface>(Type implementationType, string name = null) where TInterface : class
+        {
+            Type interfaceType = typeof(TInterface);
+            return RegisterTypeAs(implementationType, interfaceType, name);
+        }
+
+        public IStrategyRegistration RegisterTypeAs<TType, TInterface>(string name = null) where TType : class, TInterface
+        {
+            Type interfaceType = typeof(TInterface);
+            Type implementationType = typeof(TType);
+            return RegisterTypeAs(implementationType, interfaceType, name);
+        }
+
+        public IStrategyRegistration RegisterTypeAs(Type implementationType, Type interfaceType)
+        {
+            if (!IsValidTypeMapping(implementationType, interfaceType))
+                throw new InvalidOperationException("type mapping is not valid");
+            return RegisterTypeAs(implementationType, interfaceType, null);
+        }
+
+        private bool IsValidTypeMapping(Type implementationType, Type interfaceType)
+        {
+            if (interfaceType.IsAssignableFrom(implementationType))
+                return true;
+
+            if (interfaceType.IsGenericTypeDefinition && implementationType.IsGenericTypeDefinition)
+            {
+                var baseTypes = GetBaseTypes(implementationType).ToArray();
+                return baseTypes.Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceType);
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<Type> GetBaseTypes(Type type)
+        {
+            if (type.BaseType == null) return type.GetInterfaces();
+
+            return Enumerable.Repeat(type.BaseType, 1)
+                             .Concat(type.GetInterfaces())
+                             .Concat(type.GetInterfaces().SelectMany(GetBaseTypes))
+                             .Concat(GetBaseTypes(type.BaseType));
+        }
+
+
+        private RegistrationKey CreateNamedInstanceDictionaryKey(Type targetType)
+        {
+            return new RegistrationKey(typeof(IDictionary<,>).MakeGenericType(typeof(string), targetType), null);
+        }
+
+        private void AddRegistration(RegistrationKey key, IRegistration registration)
+        {
+            registrations[key] = registration;
+
+            if (key.Name != null)
+            {
+                var dictKey = CreateNamedInstanceDictionaryKey(key.Type);
+                if (!registrations.ContainsKey(dictKey))
+                {
+                    registrations[dictKey] = new NamedInstanceDictionaryRegistration();
+                }
+            }
+        }
+
+        private IStrategyRegistration RegisterTypeAs(Type implementationType, Type interfaceType, string name)
+        {
+            var registrationKey = new RegistrationKey(interfaceType, name);
+            AssertNotResolved(registrationKey);
+
+            ClearRegistrations(registrationKey);
+            var typeRegistration = new TypeRegistration(implementationType);
+            AddRegistration(registrationKey, typeRegistration);
+
+            return typeRegistration;
+        }
+
+        public void RegisterInstanceAs(object instance, Type interfaceType, string name = null, bool dispose = false)
+        {
+            if (instance == null)
+                throw new ArgumentNullException("instance");
+            var registrationKey = new RegistrationKey(interfaceType, name);
+            AssertNotResolved(registrationKey);
+
+            ClearRegistrations(registrationKey);
+            AddRegistration(registrationKey, new InstanceRegistration(instance));
+            objectPool[new RegistrationKey(instance.GetType(), name)] = GetPoolableInstance(instance, dispose);
+        }
+
+        private static object GetPoolableInstance(object instance, bool dispose)
+        {
+            return (instance is IDisposable) && !dispose ? new NonDisposableWrapper(instance) : instance;
+        }
+
+        public void RegisterInstanceAs<TInterface>(TInterface instance, string name = null, bool dispose = false) where TInterface : class
+        {
+            RegisterInstanceAs(instance, typeof(TInterface), name, dispose);
+        }
+
+        public IStrategyRegistration RegisterFactoryAs<TInterface>(Func<TInterface> factoryDelegate, string name = null)
+        {
+            return RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+        }
+
+        public IStrategyRegistration RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null)
+        {
+            return RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+        }
+
+        public void RegisterFactoryAs<TInterface>(Delegate factoryDelegate, string name = null)
+        {
+            RegisterFactoryAs(factoryDelegate, typeof(TInterface), name);
+        }
+
+        public IStrategyRegistration RegisterFactoryAs(Delegate factoryDelegate, Type interfaceType, string name = null)
+        {
+            if (factoryDelegate == null) throw new ArgumentNullException("factoryDelegate");
+            if (interfaceType == null) throw new ArgumentNullException("interfaceType");
+
+            var registrationKey = new RegistrationKey(interfaceType, name);
+            AssertNotResolved(registrationKey);
+
+            ClearRegistrations(registrationKey);
+            var factoryRegistration = new FactoryRegistration(factoryDelegate);
+            AddRegistration(registrationKey, factoryRegistration);
+
+            return factoryRegistration;
+        }
+
+        public bool IsRegistered<T>()
+        {
+            return this.IsRegistered<T>(null);
+        }
+
+        public bool IsRegistered<T>(string name)
+        {
+            Type typeToResolve = typeof(T);
+
+            var keyToResolve = new RegistrationKey(typeToResolve, name);
+
+            return registrations.ContainsKey(keyToResolve);
+        }
+
+        // ReSharper disable once UnusedParameter.Local
+        private void AssertNotResolved(RegistrationKey interfaceType)
+        {
+            if (resolvedKeys.Contains(interfaceType))
+                throw new ObjectContainerException("An object has been resolved for this interface already.", null);
+        }
+
+        private void ClearRegistrations(RegistrationKey registrationKey)
+        {
+            registrations.Remove(registrationKey);
+        }
+
+#if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT
+        public void RegisterFromConfiguration()
+        {
+            var section = (BoDiConfigurationSection)ConfigurationManager.GetSection("boDi");
+            if (section == null)
+                return;
+
+            RegisterFromConfiguration(section.Registrations);
+        }
+
+        public void RegisterFromConfiguration(ContainerRegistrationCollection containerRegistrationCollection)
+        {
+            if (containerRegistrationCollection == null)
+                return;
+
+            foreach (ContainerRegistrationConfigElement registrationConfigElement in containerRegistrationCollection)
+            {
+                RegisterFromConfiguration(registrationConfigElement);
+            }
+        }
+
+        private void RegisterFromConfiguration(ContainerRegistrationConfigElement registrationConfigElement)
+        {
+            Type interfaceType = Type.GetType(registrationConfigElement.Interface, true);
+            Type implementationType = Type.GetType(registrationConfigElement.Implementation, true);
+
+            RegisterTypeAs(implementationType, interfaceType, string.IsNullOrEmpty(registrationConfigElement.Name) ? null : registrationConfigElement.Name);
+        }
+#endif
+
+        #endregion
+
+        #region Resolve
+
+        private readonly object resolutionLock = new object();
+
+        public T Resolve<T>()
+        {
+            return Resolve<T>(null);
+        }
+
+        public T Resolve<T>(string name)
+        {
+            Type typeToResolve = typeof(T);
+
+            lock (resolutionLock)
+            {
+                object resolvedObject = ResolveInternal(typeToResolve, new ResolutionList(), name);
+                return (T)resolvedObject;
+            }
+        }
+
+        public object Resolve(Type typeToResolve, string name = null)
+        {
+            lock (resolutionLock)
+            {
+                return ResolveInternal(typeToResolve, new ResolutionList(), name);
+            }
+        }
+
+        public IEnumerable<T> ResolveAll<T>() where T : class
+        {
+            lock (resolutionLock)
+            {
+                return registrations
+                    .Where(x => x.Key.Type == typeof(T))
+                    .Select(x => ResolveInternal(x.Key.Type, new ResolutionList(), x.Key.Name) as T)
+                    .ToList(); // need to force enumeration to ensure thread safety for the whole enumeration
+            }
+        }
+
+        private object ResolveInternal(Type typeToResolve, ResolutionList resolutionPath, string name)
+        {
+            AssertNotDisposed();
+
+            var keyToResolve = new RegistrationKey(typeToResolve, name);
+            object resolvedObject = ResolveObject(keyToResolve, resolutionPath);
+            if (!resolvedKeys.Contains(keyToResolve))
+            {
+                resolvedKeys.Add(keyToResolve);
+            }
+            Debug.Assert(typeToResolve.IsInstanceOfType(resolvedObject));
+            return resolvedObject;
+        }
+
+        private KeyValuePair<ObjectContainer, IRegistration>? GetRegistrationResult(RegistrationKey keyToResolve)
+        {
+            IRegistration registration;
+            if (registrations.TryGetValue(keyToResolve, out registration))
+            {
+                return new KeyValuePair<ObjectContainer, IRegistration>(this, registration);
+            }
+
+            if (baseContainer != null)
+                return baseContainer.GetRegistrationResult(keyToResolve);
+
+            if (IsSpecialNamedInstanceDictionaryKey(keyToResolve))
+            {
+                var targetType = keyToResolve.Type.GetGenericArguments()[1];
+                return GetRegistrationResult(CreateNamedInstanceDictionaryKey(targetType));
+            }
+
+            // if there was no named registration, we still return an empty dictionary
+            if (IsDefaultNamedInstanceDictionaryKey(keyToResolve))
+            {
+                return new KeyValuePair<ObjectContainer, IRegistration>(this, new NamedInstanceDictionaryRegistration());
+            }
+
+            return null;
+        }
+
+        private bool IsDefaultNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+        {
+            return IsNamedInstanceDictionaryKey(keyToResolve) && 
+                   keyToResolve.Type.GetGenericArguments()[0] == typeof(string);
+        }
+
+        private bool IsSpecialNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+        {
+            return IsNamedInstanceDictionaryKey(keyToResolve) && 
+                   keyToResolve.Type.GetGenericArguments()[0].IsEnum;
+        }
+
+        private bool IsNamedInstanceDictionaryKey(RegistrationKey keyToResolve)
+        {
+            return keyToResolve.Name == null && keyToResolve.Type.IsGenericType && keyToResolve.Type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
+        }
+
+        private object GetPooledObject(RegistrationKey pooledObjectKey)
+        {
+            object obj;
+            if (GetObjectFromPool(pooledObjectKey, out obj))
+                return obj;
+
+            return null;
+        }
+
+        private bool GetObjectFromPool(RegistrationKey pooledObjectKey, out object obj)
+        {
+            if (!objectPool.TryGetValue(pooledObjectKey, out obj))
+                return false;
+
+            var nonDisposableWrapper = obj as NonDisposableWrapper;
+            if (nonDisposableWrapper != null)
+                obj = nonDisposableWrapper.Object;
+
+            return true;
+        }
+
+        private object ResolveObject(RegistrationKey keyToResolve, ResolutionList resolutionPath)
+        {
+            if (keyToResolve.Type.IsPrimitive || keyToResolve.Type == typeof(string) || keyToResolve.Type.IsValueType)
+                throw new ObjectContainerException("Primitive types or structs cannot be resolved: " + keyToResolve.Type.FullName, resolutionPath.ToTypeList());
+
+            var registrationResult = GetRegistrationResult(keyToResolve);
+            var isImplicitTypeRegistration = registrationResult == null;
+            var registrationToUse = registrationResult ??
+                new KeyValuePair<ObjectContainer, IRegistration>(this, new TypeRegistration(keyToResolve.Type));
+
+            var resolutionPathForResolve = registrationToUse.Key == this ? 
+                resolutionPath : new ResolutionList();
+            var result = registrationToUse.Value.Resolve(registrationToUse.Key, keyToResolve, resolutionPathForResolve);
+            if (isImplicitTypeRegistration) // upon successful implicit registration, we register the rule, so that sub context can also get the same resolved value
+                AddRegistration(keyToResolve, registrationToUse.Value);
+            return result;
+        }
+
+        private object CreateObject(Type type, ResolutionList resolutionPath, RegistrationKey keyToResolve)
+        {
+            var ctors = type.GetConstructors();
+            if (ctors.Length == 0)
+                ctors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Debug.Assert(ctors.Length > 0, "Class must have a constructor!");
+
+            int maxParamCount = ctors.Max(ctor => ctor.GetParameters().Length);
+            var maxParamCountCtors = ctors.Where(ctor => ctor.GetParameters().Length == maxParamCount).ToArray();
+
+            object obj;
+            if (maxParamCountCtors.Length == 1)
+            {
+                ConstructorInfo ctor = maxParamCountCtors[0];
+                if (resolutionPath.Contains(keyToResolve))
+                    throw new ObjectContainerException("Circular dependency found! " + type.FullName, resolutionPath.ToTypeList());
+
+                var args = ResolveArguments(ctor.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, type));
+                obj = ctor.Invoke(args);
+            }
+            else
+            {
+                throw new ObjectContainerException("Multiple public constructors with same maximum parameter count are not supported! " + type.FullName, resolutionPath.ToTypeList());
+            }
+
+            OnObjectCreated(obj);
+
+            return obj;
+        }
+
+        protected virtual void OnObjectCreated(object obj)
+        {
+            var eventHandler = ObjectCreated;
+            if (eventHandler != null)
+                eventHandler(obj);
+        }
+
+        private object InvokeFactoryDelegate(Delegate factoryDelegate, ResolutionList resolutionPath, RegistrationKey keyToResolve)
+        {
+            if (resolutionPath.Contains(keyToResolve))
+                throw new ObjectContainerException("Circular dependency found! " + factoryDelegate.ToString(), resolutionPath.ToTypeList());
+
+            var args = ResolveArguments(factoryDelegate.Method.GetParameters(), keyToResolve, resolutionPath.AddToEnd(keyToResolve, null));
+            return factoryDelegate.DynamicInvoke(args);
+        }
+
+        private object[] ResolveArguments(IEnumerable<ParameterInfo> parameters, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+        {
+            return parameters.Select(p => IsRegisteredNameParameter(p) ? ResolveRegisteredName(keyToResolve) : ResolveInternal(p.ParameterType, resolutionPath, null)).ToArray();
+        }
+
+        private object ResolveRegisteredName(RegistrationKey keyToResolve)
+        {
+            return keyToResolve.Name;
+        }
+
+        private bool IsRegisteredNameParameter(ParameterInfo parameterInfo)
+        {
+            return parameterInfo.ParameterType == typeof (string) &&
+                   parameterInfo.Name.Equals(REGISTERED_NAME_PARAMETER_NAME);
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            return string.Join(Environment.NewLine,
+                registrations
+                    .Where(r => !(r.Value is NamedInstanceDictionaryRegistration))
+                    .Select(r => string.Format("{0} -> {1}", r.Key, (r.Key.Type == typeof(IObjectContainer) && r.Key.Name == null) ? "<self>" : r.Value.ToString())));
+        }
+
+        private void AssertNotDisposed()
+        {
+            if (isDisposed)
+                throw new ObjectContainerException("Object container disposed", null);
+        }
+
+        public void Dispose()
+        {
+            isDisposed = true;
+
+            foreach (var obj in objectPool.Values.OfType<IDisposable>().Where(o => !ReferenceEquals(o, this)))
+                obj.Dispose();
+
+            objectPool.Clear();
+            registrations.Clear();
+            resolvedKeys.Clear();
+        }
+    }
+
+    #region Configuration handling
+#if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT
+
+    public class BoDiConfigurationSection : ConfigurationSection
+    {
+        [ConfigurationProperty("", Options = ConfigurationPropertyOptions.IsDefaultCollection)]
+        [ConfigurationCollection(typeof(ContainerRegistrationCollection), AddItemName = "register")]
+        public ContainerRegistrationCollection Registrations
+        {
+            get { return (ContainerRegistrationCollection)this[""]; }
+            set { this[""] = value; }
+        }
+    }
+
+    public class ContainerRegistrationCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new ContainerRegistrationConfigElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            var registrationConfigElement = ((ContainerRegistrationConfigElement)element);
+            string elementKey = registrationConfigElement.Interface;
+            if (registrationConfigElement.Name != null)
+                elementKey = elementKey + "/" + registrationConfigElement.Name;
+            return elementKey;
+        }
+
+        public void Add(string implementationType, string interfaceType, string name = null)
+        {
+            BaseAdd(new ContainerRegistrationConfigElement
+                        {
+                            Implementation = implementationType,
+                            Interface = interfaceType,
+                            Name = name
+                        });
+        }
+    }
+
+    public class ContainerRegistrationConfigElement : ConfigurationElement
+    {
+        [ConfigurationProperty("as", IsRequired = true)]
+        public string Interface
+        {
+            get { return (string)this["as"]; }
+            set { this["as"] = value; }
+        }
+
+        [ConfigurationProperty("type", IsRequired = true)]
+        public string Implementation
+        {
+            get { return (string)this["type"]; }
+            set { this["type"] = value; }
+        }
+
+        [ConfigurationProperty("name", IsRequired = false, DefaultValue = null)]
+        public string Name
+        {
+            get { return (string)this["name"]; }
+            set { this["name"] = value; }
+        }
+    }
+
+#endif
+    #endregion
+}

--- a/BoDi.Performance.Tests/Benchmarks/BenchmarkBase.cs
+++ b/BoDi.Performance.Tests/Benchmarks/BenchmarkBase.cs
@@ -1,0 +1,59 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using BoDi;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    [HtmlExporter]
+    [MarkdownExporterAttribute.GitHub]
+    [MinColumn, MaxColumn, MeanColumn, MedianColumn, RankColumn]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
+    public abstract class BenchmarkBase
+    {
+        protected internal IObjectContainer ContainerCurrent;
+        protected internal BoDi1_4.IObjectContainer Container14;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Container14 = new BoDi1_4.ObjectContainer();
+            Container14.RegisterFactoryAs(_ => new FactoryRegistered());
+            Container14.RegisterTypeAs<TypeRegistered, TypeRegistered>();
+            Container14.RegisterTypeAs<AllRegistered1, IAllRegisteredFromType>();
+            Container14.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
+            Container14.RegisterTypeAs<AllRegistered3, IAllRegisteredFromType>();
+            Container14.RegisterTypeAs<AllRegistered4, IAllRegisteredFromType>();
+            Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered1());
+            Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
+            Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
+            Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered4());
+
+
+            ContainerCurrent = new ObjectContainer();
+            ContainerCurrent.RegisterFactoryAs(_ => new FactoryRegistered());
+            ContainerCurrent.RegisterTypeAs<TypeRegistered, TypeRegistered>();
+            ContainerCurrent.RegisterTypeAs<AllRegistered1, IAllRegisteredFromType>();
+            ContainerCurrent.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
+            ContainerCurrent.RegisterTypeAs<AllRegistered3, IAllRegisteredFromType>();
+            ContainerCurrent.RegisterTypeAs<AllRegistered4, IAllRegisteredFromType>();
+            ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered1());
+            ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
+            ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
+            ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered4());
+
+        }
+
+        protected internal class FactoryRegistered { }
+
+        protected internal class TypeRegistered { }
+
+        protected internal interface IAllRegisteredFromType { }
+
+        protected internal interface IAllRegisteredFromFactory { }
+
+        private class AllRegistered1 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+        private class AllRegistered2 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+        private class AllRegistered3 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+        private class AllRegistered4 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/MultipleContainerBenchmarkBase.cs
+++ b/BoDi.Performance.Tests/Benchmarks/MultipleContainerBenchmarkBase.cs
@@ -1,0 +1,38 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using BoDi;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    [HtmlExporter]
+    [MarkdownExporterAttribute.GitHub]
+    [MinColumn, MaxColumn, MeanColumn, MedianColumn, RankColumn]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
+    public abstract class MultipleContainerBenchmarkBase
+    {
+        protected internal IObjectContainer ContainerCurrentLevel1;
+        protected internal IObjectContainer ContainerCurrentLevel2;
+        protected internal IObjectContainer ContainerCurrentLevel3;
+        protected internal IObjectContainer ContainerCurrentLevel4;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            ContainerCurrentLevel1 = new ObjectContainer();
+            ContainerCurrentLevel2 = new ObjectContainer(ContainerCurrentLevel1);
+            ContainerCurrentLevel3 = new ObjectContainer(ContainerCurrentLevel2);
+            ContainerCurrentLevel4 = new ObjectContainer(ContainerCurrentLevel3);
+            ContainerCurrentLevel1.RegisterTypeAs<TypeRegisteredLevel1, TypeRegisteredLevel1>();
+            ContainerCurrentLevel2.RegisterTypeAs<TypeRegisteredLevel2, TypeRegisteredLevel2>();
+            ContainerCurrentLevel3.RegisterTypeAs<TypeRegisteredLevel3, TypeRegisteredLevel3>();
+            ContainerCurrentLevel4.RegisterTypeAs<TypeRegisteredLevel4, TypeRegisteredLevel4>();
+
+        }
+
+        protected internal class TypeRegisteredLevel1 { }
+        protected internal class TypeRegisteredLevel2 { }
+        protected internal class TypeRegisteredLevel3 { }
+        protected internal class TypeRegisteredLevel4 { }
+
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactory.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactory.cs
@@ -21,7 +21,8 @@ namespace BODi.Performance.Tests.Benchmarks
         [Benchmark(Description = "Current")]
         public object CurrentVersion()
         {
-            return ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>();
+            // current returns a yet unresolved IEnumerable, so we need to force resolution
+            return ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>().ToList();
         }
     }
 }

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactory.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactory.cs
@@ -3,13 +3,19 @@ using BenchmarkDotNet.Attributes;
 
 namespace BODi.Performance.Tests.Benchmarks
 {
-    public class ResolveAllFromFactory : BenchmarkBase
+    public class ResolveAllFromFactory : SingleContainerBenchmarkBase
     {
         [Benchmark(Baseline = true, Description = "v1.4")]
         public object Version_1_4()
         {
             // v1.4 returned a yet unresolved IEnumerable, so we need to force resolution
             return Container14.ResolveAll<IAllRegisteredFromFactory>().ToList();
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            return Container1NextFlawed.ResolveAll<IAllRegisteredFromFactory>();
         }
 
         [Benchmark(Description = "Current")]

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactory.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactory.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveAllFromFactory : BenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            // v1.4 returned a yet unresolved IEnumerable, so we need to force resolution
+            return Container14.ResolveAll<IAllRegisteredFromFactory>().ToList();
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            return ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactoryRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactoryRepeated.cs
@@ -6,7 +6,7 @@ namespace BODi.Performance.Tests.Benchmarks
 {
     public class ResolveAllFromFactoryRepeated : SingleContainerBenchmarkBase
     {
-        [Params(10)]
+        [Params(100)]
         public int Repetitions { get; set; }
 
         [Benchmark(Baseline = true, Description = "v1.4")]
@@ -37,10 +37,11 @@ namespace BODi.Performance.Tests.Benchmarks
         [Benchmark(Description = "Current")]
         public object CurrentVersion()
         {
-            IEnumerable<IAllRegisteredFromFactory> obj = null;
+            List<IAllRegisteredFromFactory> obj = null;
             for (int i = 0; i < Repetitions; i++)
             {
-                obj = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>();
+                // current returns a yet unresolved IEnumerable, so we need to force resolution
+                obj = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>().ToList();
             }
 
             return obj;

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactoryRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromFactoryRepeated.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveAllFromFactoryRepeated : SingleContainerBenchmarkBase
+    {
+        [Params(10)]
+        public int Repetitions { get; set; }
+
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            List<IAllRegisteredFromFactory> obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                // v1.4 returned a yet unresolved IEnumerable, so we need to force resolution
+                obj = Container14.ResolveAll<IAllRegisteredFromFactory>().ToList();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            IEnumerable<IAllRegisteredFromFactory> obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = Container1NextFlawed.ResolveAll<IAllRegisteredFromFactory>();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            IEnumerable<IAllRegisteredFromFactory> obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>();
+            }
+
+            return obj;
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromType.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromType.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveAllFromType : BenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            // v1.4 returned a yet unresolved IEnumerable, so we need to force resolution
+            return Container14.ResolveAll<IAllRegisteredFromType>().ToList();
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            return ContainerCurrent.ResolveAll<IAllRegisteredFromType>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromType.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromType.cs
@@ -21,7 +21,8 @@ namespace BODi.Performance.Tests.Benchmarks
         [Benchmark(Description = "Current")]
         public object CurrentVersion()
         {
-            return ContainerCurrent.ResolveAll<IAllRegisteredFromType>();
+            // current returns a yet unresolved IEnumerable, so we need to force resolution
+            return ContainerCurrent.ResolveAll<IAllRegisteredFromType>().ToList();
         }
     }
 }

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromType.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromType.cs
@@ -3,13 +3,19 @@ using BenchmarkDotNet.Attributes;
 
 namespace BODi.Performance.Tests.Benchmarks
 {
-    public class ResolveAllFromType : BenchmarkBase
+    public class ResolveAllFromType : SingleContainerBenchmarkBase
     {
         [Benchmark(Baseline = true, Description = "v1.4")]
         public object Version_1_4()
         {
             // v1.4 returned a yet unresolved IEnumerable, so we need to force resolution
             return Container14.ResolveAll<IAllRegisteredFromType>().ToList();
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            return Container1NextFlawed.ResolveAll<IAllRegisteredFromType>();
         }
 
         [Benchmark(Description = "Current")]

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromTypeRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromTypeRepeated.cs
@@ -6,7 +6,7 @@ namespace BODi.Performance.Tests.Benchmarks
 {
     public class ResolveAllFromTypeRepeated : SingleContainerBenchmarkBase
     {
-        [Params(10)]
+        [Params(100)]
         public int Repetitions { get; set; }
 
 
@@ -38,10 +38,11 @@ namespace BODi.Performance.Tests.Benchmarks
         [Benchmark(Description = "Current")]
         public object CurrentVersion()
         {
-            IEnumerable<IAllRegisteredFromType> obj = null;
+            List<IAllRegisteredFromType> obj = null;
             for (int i = 0; i < Repetitions; i++)
             {
-                obj = ContainerCurrent.ResolveAll<IAllRegisteredFromType>();
+                // current returns a yet unresolved IEnumerable, so we need to force resolution
+                obj = ContainerCurrent.ResolveAll<IAllRegisteredFromType>().ToList();
             }
 
             return obj;

--- a/BoDi.Performance.Tests/Benchmarks/ResolveAllFromTypeRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveAllFromTypeRepeated.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveAllFromTypeRepeated : SingleContainerBenchmarkBase
+    {
+        [Params(10)]
+        public int Repetitions { get; set; }
+
+
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            List<IAllRegisteredFromType> obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                // v1.4 returned a yet unresolved IEnumerable, so we need to force resolution
+                obj = Container14.ResolveAll<IAllRegisteredFromType>().ToList();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            IEnumerable<IAllRegisteredFromType> obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = Container1NextFlawed.ResolveAll<IAllRegisteredFromType>();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            IEnumerable<IAllRegisteredFromType> obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = ContainerCurrent.ResolveAll<IAllRegisteredFromType>();
+            }
+
+            return obj;
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromFactory.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromFactory.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveFromFactory : BenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            return Container14.Resolve<FactoryRegistered>();
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            return ContainerCurrent.Resolve<FactoryRegistered>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromFactory.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromFactory.cs
@@ -2,12 +2,18 @@
 
 namespace BODi.Performance.Tests.Benchmarks
 {
-    public class ResolveFromFactory : BenchmarkBase
+    public class ResolveFromFactory : SingleContainerBenchmarkBase
     {
         [Benchmark(Baseline = true, Description = "v1.4")]
         public object Version_1_4()
         {
             return Container14.Resolve<FactoryRegistered>();
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            return Container1NextFlawed.Resolve<FactoryRegistered>();
         }
 
         [Benchmark(Description = "Current")]

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromFactoryRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromFactoryRepeated.cs
@@ -1,0 +1,47 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveFromFactoryRepeated : SingleContainerBenchmarkBase
+    {
+        [Params(10)]
+        public int Repetitions { get; set; }
+
+
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            FactoryRegistered obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = Container14.Resolve<FactoryRegistered>();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            FactoryRegistered obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = Container1NextFlawed.Resolve<FactoryRegistered>();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            FactoryRegistered obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = ContainerCurrent.Resolve<FactoryRegistered>();
+            }
+
+            return obj;
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromFactoryRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromFactoryRepeated.cs
@@ -4,7 +4,7 @@ namespace BODi.Performance.Tests.Benchmarks
 {
     public class ResolveFromFactoryRepeated : SingleContainerBenchmarkBase
     {
-        [Params(10)]
+        [Params(100)]
         public int Repetitions { get; set; }
 
 

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromType.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromType.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveFromType : BenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            return Container14.Resolve<TypeRegistered>();
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            return ContainerCurrent.Resolve<TypeRegistered>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromType.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromType.cs
@@ -2,12 +2,18 @@
 
 namespace BODi.Performance.Tests.Benchmarks
 {
-    public class ResolveFromType : BenchmarkBase
+    public class ResolveFromType : SingleContainerBenchmarkBase
     {
         [Benchmark(Baseline = true, Description = "v1.4")]
         public object Version_1_4()
         {
             return Container14.Resolve<TypeRegistered>();
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            return Container1NextFlawed.Resolve<TypeRegistered>();
         }
 
         [Benchmark(Description = "Current")]

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromTypeRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromTypeRepeated.cs
@@ -4,7 +4,7 @@ namespace BODi.Performance.Tests.Benchmarks
 {
     public class ResolveFromTypeRepeated : SingleContainerBenchmarkBase
     {
-        [Params(10)]
+        [Params(100)]
         public int Repetitions { get; set; }
 
 
@@ -14,7 +14,7 @@ namespace BODi.Performance.Tests.Benchmarks
             TypeRegistered obj = null;
             for (int i = 0; i < Repetitions; i++)
             {
-                obj = ContainerCurrent.Resolve<TypeRegistered>();
+                obj = Container14.Resolve<TypeRegistered>();
             }
 
             return obj;
@@ -26,7 +26,7 @@ namespace BODi.Performance.Tests.Benchmarks
             TypeRegistered obj = null;
             for (int i = 0; i < Repetitions; i++)
             {
-                obj = ContainerCurrent.Resolve<TypeRegistered>();
+                obj = Container1NextFlawed.Resolve<TypeRegistered>();
             }
 
             return obj;

--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromTypeRepeated.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromTypeRepeated.cs
@@ -1,0 +1,47 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveFromTypeRepeated : SingleContainerBenchmarkBase
+    {
+        [Params(10)]
+        public int Repetitions { get; set; }
+
+
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            TypeRegistered obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = ContainerCurrent.Resolve<TypeRegistered>();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public object Version_1_Next_Flawed()
+        {
+            TypeRegistered obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = ContainerCurrent.Resolve<TypeRegistered>();
+            }
+
+            return obj;
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            TypeRegistered obj = null;
+            for (int i = 0; i < Repetitions; i++)
+            {
+                obj = ContainerCurrent.Resolve<TypeRegistered>();
+            }
+
+            return obj;
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedMultipleContainer.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedMultipleContainer.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using BODi.Performance.Tests.Benchmarks;
+
+namespace BoDi.Performance.Tests.Benchmarks
+{
+    public class ResolveMultiThreadedMultipleContainer : MultipleContainerBenchmarkBase
+    {
+        [Params(2, 4, 8, 16)]
+        public int ThreadCount { get; set; }
+
+        [Params(2048)]
+        public int Loops { get; set; }
+
+        [Benchmark(Description = "Current")]
+        public void CurrentVersion()
+        {
+            void Resolve(object _)
+            {
+                for (int i = 0; i < Loops / ThreadCount; i++)
+                {
+                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel4>();
+                    _ = ContainerCurrentLevel3.ResolveAll<TypeRegisteredLevel3>().ToList();
+                    _ = ContainerCurrentLevel3.Resolve<TypeRegisteredLevel4>();
+                    _ = ContainerCurrentLevel4.ResolveAll<TypeRegisteredLevel4>();
+                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel3>().ToList();
+                    _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel2>();
+                    _ = ContainerCurrentLevel2.Resolve<TypeRegisteredLevel2>();
+                    _ = ContainerCurrentLevel1.ResolveAll<TypeRegisteredLevel3>().ToList();
+                    _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel1>();
+                    _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel4>();
+                }
+            }
+            StartAndJoin(Resolve);
+        }
+
+        private void StartAndJoin(ParameterizedThreadStart parameterizedThreadStart)
+        {
+            var threads = Enumerable.Range(1, ThreadCount)
+                .Select(_ => new Thread(parameterizedThreadStart))
+                .ToList();
+            foreach (var t in threads)
+            {
+                t.Start();
+            }
+
+            foreach (var t in threads)
+            {
+                t.Join();
+            }
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedMultipleContainer.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedMultipleContainer.cs
@@ -20,14 +20,14 @@ namespace BoDi.Performance.Tests.Benchmarks
             {
                 for (int i = 0; i < Loops / ThreadCount; i++)
                 {
-                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel4>();
-                    _ = ContainerCurrentLevel3.ResolveAll<TypeRegisteredLevel3>();
+                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel4>().ToList();
+                    _ = ContainerCurrentLevel3.ResolveAll<TypeRegisteredLevel3>().ToList();
                     _ = ContainerCurrentLevel3.Resolve<TypeRegisteredLevel4>();
-                    _ = ContainerCurrentLevel4.ResolveAll<TypeRegisteredLevel4>();
-                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel3>();
+                    _ = ContainerCurrentLevel4.ResolveAll<TypeRegisteredLevel4>().ToList();
+                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel3>().ToList();
                     _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel2>();
                     _ = ContainerCurrentLevel2.Resolve<TypeRegisteredLevel2>();
-                    _ = ContainerCurrentLevel1.ResolveAll<TypeRegisteredLevel3>();
+                    _ = ContainerCurrentLevel1.ResolveAll<TypeRegisteredLevel3>().ToList();
                     _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel1>();
                     _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel4>();
                 }

--- a/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedMultipleContainer.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedMultipleContainer.cs
@@ -21,13 +21,13 @@ namespace BoDi.Performance.Tests.Benchmarks
                 for (int i = 0; i < Loops / ThreadCount; i++)
                 {
                     _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel4>();
-                    _ = ContainerCurrentLevel3.ResolveAll<TypeRegisteredLevel3>().ToList();
+                    _ = ContainerCurrentLevel3.ResolveAll<TypeRegisteredLevel3>();
                     _ = ContainerCurrentLevel3.Resolve<TypeRegisteredLevel4>();
                     _ = ContainerCurrentLevel4.ResolveAll<TypeRegisteredLevel4>();
-                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel3>().ToList();
+                    _ = ContainerCurrentLevel2.ResolveAll<TypeRegisteredLevel3>();
                     _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel2>();
                     _ = ContainerCurrentLevel2.Resolve<TypeRegisteredLevel2>();
-                    _ = ContainerCurrentLevel1.ResolveAll<TypeRegisteredLevel3>().ToList();
+                    _ = ContainerCurrentLevel1.ResolveAll<TypeRegisteredLevel3>();
                     _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel1>();
                     _ = ContainerCurrentLevel1.Resolve<TypeRegisteredLevel4>();
                 }

--- a/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedSingleContainer.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedSingleContainer.cs
@@ -36,8 +36,8 @@ namespace BoDi.Performance.Tests.Benchmarks
             {
                 for (int i = 0; i < Loops / ThreadCount; i++)
                 {
-                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>();
-                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromType>();
+                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>().ToList();
+                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromType>().ToList();
                     _ = ContainerCurrent.Resolve<FactoryRegistered>();
                     _ = ContainerCurrent.Resolve<TypeRegistered>();
                 }

--- a/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedSingleContainer.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedSingleContainer.cs
@@ -20,8 +20,8 @@ namespace BoDi.Performance.Tests.Benchmarks
             {
                 for (int i = 0; i < Loops / ThreadCount; i++)
                 {
-                    _ = Container1NextFlawed.ResolveAll<IAllRegisteredFromFactory>().ToList();
-                    _ = Container1NextFlawed.ResolveAll<IAllRegisteredFromType>().ToList();
+                    _ = Container1NextFlawed.ResolveAll<IAllRegisteredFromFactory>();
+                    _ = Container1NextFlawed.ResolveAll<IAllRegisteredFromType>();
                     _ = Container1NextFlawed.Resolve<FactoryRegistered>();
                     _ = Container1NextFlawed.Resolve<TypeRegistered>();
                 }
@@ -36,8 +36,8 @@ namespace BoDi.Performance.Tests.Benchmarks
             {
                 for (int i = 0; i < Loops / ThreadCount; i++)
                 {
-                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>().ToList();
-                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromType>().ToList();
+                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>();
+                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromType>();
                     _ = ContainerCurrent.Resolve<FactoryRegistered>();
                     _ = ContainerCurrent.Resolve<TypeRegistered>();
                 }

--- a/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedSingleContainer.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveMultiThreadedSingleContainer.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using BODi.Performance.Tests.Benchmarks;
+
+namespace BoDi.Performance.Tests.Benchmarks
+{
+    public class ResolveMultiThreadedSingleContainer : SingleContainerBenchmarkBase
+    {
+        [Params(2, 4, 8, 16)]
+        public int ThreadCount { get; set; }
+
+        [Params(2048)]
+        public int Loops { get; set; }
+
+        [Benchmark(Description = "v1.Next-Flawed")]
+        public void Version_1_Next_Flawed()
+        {
+            void Resolve(object _)
+            {
+                for (int i = 0; i < Loops / ThreadCount; i++)
+                {
+                    _ = Container1NextFlawed.ResolveAll<IAllRegisteredFromFactory>().ToList();
+                    _ = Container1NextFlawed.ResolveAll<IAllRegisteredFromType>().ToList();
+                    _ = Container1NextFlawed.Resolve<FactoryRegistered>();
+                    _ = Container1NextFlawed.Resolve<TypeRegistered>();
+                }
+            }
+            StartAndJoin(Resolve);
+        }
+
+        [Benchmark(Description = "Current")]
+        public void CurrentVersion()
+        {
+            void Resolve(object _)
+            {
+                for (int i = 0; i < Loops / ThreadCount; i++)
+                {
+                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromFactory>().ToList();
+                    _ = ContainerCurrent.ResolveAll<IAllRegisteredFromType>().ToList();
+                    _ = ContainerCurrent.Resolve<FactoryRegistered>();
+                    _ = ContainerCurrent.Resolve<TypeRegistered>();
+                }
+            }
+            StartAndJoin(Resolve);
+        }
+
+        private void StartAndJoin(ParameterizedThreadStart parameterizedThreadStart)
+        {
+            var threads = Enumerable.Range(1, ThreadCount)
+                .Select(_ => new Thread(parameterizedThreadStart))
+                .ToList();
+            foreach (var t in threads)
+            {
+                t.Start();
+            }
+
+            foreach (var t in threads)
+            {
+                t.Join();
+            }
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/SingleContainerBenchmarkBase.cs
+++ b/BoDi.Performance.Tests/Benchmarks/SingleContainerBenchmarkBase.cs
@@ -8,10 +8,11 @@ namespace BODi.Performance.Tests.Benchmarks
     [MarkdownExporterAttribute.GitHub]
     [MinColumn, MaxColumn, MeanColumn, MedianColumn, RankColumn]
     [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
-    public abstract class BenchmarkBase
+    public abstract class SingleContainerBenchmarkBase
     {
         protected internal IObjectContainer ContainerCurrent;
         protected internal BoDi1_4.IObjectContainer Container14;
+        protected internal BoDi1_Next_Flawed.IObjectContainer Container1NextFlawed;
 
         [GlobalSetup]
         public void Setup()
@@ -28,6 +29,18 @@ namespace BODi.Performance.Tests.Benchmarks
             Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
             Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered4());
 
+
+            Container1NextFlawed = new BoDi1_Next_Flawed.ObjectContainer();
+            Container1NextFlawed.RegisterFactoryAs(_ => new FactoryRegistered());
+            Container1NextFlawed.RegisterTypeAs<TypeRegistered, TypeRegistered>();
+            Container1NextFlawed.RegisterTypeAs<AllRegistered1, IAllRegisteredFromType>();
+            Container1NextFlawed.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
+            Container1NextFlawed.RegisterTypeAs<AllRegistered3, IAllRegisteredFromType>();
+            Container1NextFlawed.RegisterTypeAs<AllRegistered4, IAllRegisteredFromType>();
+            Container1NextFlawed.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered1());
+            Container1NextFlawed.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
+            Container1NextFlawed.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
+            Container1NextFlawed.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered4());
 
             ContainerCurrent = new ObjectContainer();
             ContainerCurrent.RegisterFactoryAs(_ => new FactoryRegistered());

--- a/BoDi.Performance.Tests/BoDi.Performance.Tests.csproj
+++ b/BoDi.Performance.Tests/BoDi.Performance.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BoDi\BoDi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BoDi.Performance.Tests/Program.cs
+++ b/BoDi.Performance.Tests/Program.cs
@@ -1,0 +1,20 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+namespace BoDi.Performance.Tests
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, GetGlobalConfig());
+        }
+
+        static IConfig GetGlobalConfig()
+#if DEBUG
+            => new DebugInProcessConfig();
+#else
+            => DefaultConfig.Instance;
+#endif
+    }
+}

--- a/BoDi.Tests/ConcurrencyTests.cs
+++ b/BoDi.Tests/ConcurrencyTests.cs
@@ -1,0 +1,249 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+
+namespace BoDi.Tests
+{
+    [TestFixture]
+    public class ConcurrencyTests
+    {
+        [Test]
+        public void ShouldBeAbleToResolveFromMultipleThreadsWhenRegisteredAsType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                var registration = container.RegisterTypeAs<BlockingObject, BlockingObject>(name);
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                void Resolve(object _)
+                {
+                    Assert.That(() => container.Resolve<BlockingObject>(name), Throws.Nothing);
+                }
+
+                var thread1 = new Thread(Resolve);
+                var thread2 = new Thread(Resolve);
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldBeAbleToResolveFromMultipleThreadsWhenRegisteredAsFactory(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                container.RegisterFactoryAs(_ => new BlockingObject(), name);
+
+                void Resolve(object _)
+                {
+                    Assert.That(() => container.Resolve<BlockingObject>(name), Throws.Nothing);
+                }
+
+                var thread1 = new Thread(Resolve);
+                var thread2 = new Thread(Resolve);
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldBeAbleToResolveAllFromMultipleThreadsWhenRegisteredAsType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                container.RegisterTypeAs<BlockingObject, BlockingObject>();
+
+                void Resolve(object _)
+                {
+                    Assert.That(() => container.ResolveAll<BlockingObject>().ToList(), Throws.Nothing);
+                }
+
+                var thread1 = new Thread(Resolve);
+                var thread2 = new Thread(Resolve);
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldBeAbleToResolveAllFromMultipleThreadsWhenRegisteredAsFactory(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                container.RegisterFactoryAs(_ => new BlockingObject());
+
+                void Resolve(object _)
+                {
+                    Assert.That(() => container.ResolveAll<BlockingObject>().ToList(), Throws.Nothing);
+                }
+
+                var thread1 = new Thread(Resolve);
+                var thread2 = new Thread(Resolve);
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+        
+        private void ApplyRegistrationStrategy(IStrategyRegistration registration, RegistrationStrategy registrationStrategy)
+        {
+            switch (registrationStrategy)
+            {
+                case RegistrationStrategy.PerContext:
+                    registration.InstancePerContext();
+                    break;
+                case RegistrationStrategy.PerDependency:
+                    registration.InstancePerDependency();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(registrationStrategy), registrationStrategy, null);
+            }
+        }
+
+        public enum RegistrationStrategy
+        {
+            PerContext,
+            PerDependency
+        }
+
+        /// <summary>
+        /// This object blocks on construction, to ensure control on multi-threading use cases
+        /// </summary>
+        private class BlockingObject
+        {
+            private const int MaxBlockingObjects = 2;
+
+            public static List<EventWaitHandle> ConstructorBlockers;
+            private static int _currentConstructorBlockerIndex;
+            public static Semaphore ObjectsCreated;
+
+            static BlockingObject()
+            {
+                ResetBlockingEvents();
+            }
+
+            public static void ResetBlockingEvents()
+            {
+                if (ConstructorBlockers != null)
+                {
+                    foreach (var evt in ConstructorBlockers)
+                    {
+                        evt.Set();
+                    }
+                }
+                ConstructorBlockers = Enumerable.Repeat(new ManualResetEvent(false), MaxBlockingObjects).ToList<EventWaitHandle>();
+                _currentConstructorBlockerIndex = -1;
+                ObjectsCreated = new Semaphore(0, MaxBlockingObjects);
+            }
+
+            public BlockingObject()
+            {
+                var index = Interlocked.Increment(ref _currentConstructorBlockerIndex);
+                var evt = ConstructorBlockers[index];
+                ObjectsCreated.Release(1);
+                evt.WaitOne();
+            }
+        }
+
+        private static readonly TimeSpan ForHalfASecond = TimeSpan.FromMilliseconds(500);
+    }
+}

--- a/BoDi.Tests/ConcurrencyTests.cs
+++ b/BoDi.Tests/ConcurrencyTests.cs
@@ -62,7 +62,8 @@ namespace BoDi.Tests
             try
             {
                 IObjectContainer container = new ObjectContainer();
-                container.RegisterFactoryAs(_ => new BlockingObject(), name);
+                var registration = container.RegisterFactoryAs(_ => new BlockingObject(), name);
+                ApplyRegistrationStrategy(registration, registrationStrategy);
 
                 void Resolve(object _)
                 {
@@ -105,7 +106,8 @@ namespace BoDi.Tests
             try
             {
                 IObjectContainer container = new ObjectContainer();
-                container.RegisterTypeAs<BlockingObject, BlockingObject>();
+                var registration = container.RegisterTypeAs<BlockingObject, BlockingObject>();
+                ApplyRegistrationStrategy(registration, registrationStrategy);
 
                 void Resolve(object _)
                 {
@@ -148,7 +150,8 @@ namespace BoDi.Tests
             try
             {
                 IObjectContainer container = new ObjectContainer();
-                container.RegisterFactoryAs(_ => new BlockingObject());
+                var registration = container.RegisterFactoryAs(_ => new BlockingObject());
+                ApplyRegistrationStrategy(registration, registrationStrategy);
 
                 void Resolve(object _)
                 {

--- a/BoDi.Tests/ConcurrencyTests.cs
+++ b/BoDi.Tests/ConcurrencyTests.cs
@@ -358,6 +358,138 @@ namespace BoDi.Tests
                 BlockingObject.ResetBlockingEvents();
             }
         }
+
+        [Test]
+        public void ShouldRejectRegistrationAsTypeOnceResolveStartedOnTheSameType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                var registration = container.RegisterTypeAs<BlockingObject, BlockingObject>(name);
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread = new Thread(_ => container.Resolve<BlockingObject>(name));
+                thread.Start();
+                // wait until the object constructions is in progress, should always succeed
+                Assert.That(BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond), Is.True);
+                
+                Assert.That(() => container.RegisterTypeAs<BlockingObject, BlockingObject>(name), Throws.InstanceOf<ObjectContainerException>());
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+
+                // complete the threads
+                if (!thread.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldRejectRegistrationAsTypeOnceResolveAllStartedOnTheSameType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                var registration = container.RegisterTypeAs<BlockingObject, BlockingObject>(name);
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread = new Thread(_ => container.ResolveAll<BlockingObject>().ToList());
+                thread.Start();
+                // wait until the object constructions is in progress, should always succeed
+                Assert.That(BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond), Is.True);
+                
+                Assert.That(() => container.RegisterTypeAs<BlockingObject, BlockingObject>(name), Throws.InstanceOf<ObjectContainerException>());
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+
+                // complete the threads
+                if (!thread.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldRejectRegistrationAsFactoryOnceResolveStartedOnTheSameType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                var registration = container.RegisterFactoryAs(_ => new BlockingObject(), name);
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread = new Thread(_ => container.Resolve<BlockingObject>(name));
+                thread.Start();
+                // wait until the object constructions is in progress, should always succeed
+                Assert.That(BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond), Is.True);
+                
+                Assert.That(() => container.RegisterTypeAs<BlockingObject, BlockingObject>(name), Throws.InstanceOf<ObjectContainerException>());
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+
+                // complete the threads
+                if (!thread.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldRejectRegistrationAsFactoryOnceResolveAllStartedOnTheSameType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                IObjectContainer container = new ObjectContainer();
+                var registration = container.RegisterFactoryAs(_ => new BlockingObject(), name);
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread = new Thread(_ => container.ResolveAll<BlockingObject>().ToList());
+                thread.Start();
+                // wait until the object constructions is in progress, should always succeed
+                Assert.That(BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond), Is.True);
+                
+                Assert.That(() => container.RegisterTypeAs<BlockingObject, BlockingObject>(name), Throws.InstanceOf<ObjectContainerException>());
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+
+                // complete the threads
+                if (!thread.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
         
         private void ApplyRegistrationStrategy(IStrategyRegistration registration, RegistrationStrategy registrationStrategy)
         {

--- a/BoDi.Tests/ConcurrencyTests.cs
+++ b/BoDi.Tests/ConcurrencyTests.cs
@@ -183,6 +183,178 @@ namespace BoDi.Tests
                 BlockingObject.ResetBlockingEvents();
             }
         }
+
+        [Test]
+        public void ShouldBeAbleToResolveFromMultipleThreadsFromContainerHierarchyWhenRegisteredAsType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                
+                IObjectContainer baseContainer = new ObjectContainer();
+                IObjectContainer childContainer = new ObjectContainer(baseContainer);
+                var registration = baseContainer.RegisterTypeAs<BlockingObject, BlockingObject>(name);
+                
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread1 = new Thread(_ => Assert.That(() => baseContainer.Resolve<BlockingObject>(name), Throws.Nothing));
+                var thread2 = new Thread(_ => Assert.That(() => childContainer.Resolve<BlockingObject>(name), Throws.Nothing));
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldBeAbleToResolveFromMultipleThreadsFromContainerHierarchyWhenRegisteredAsFactory(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                
+                IObjectContainer baseContainer = new ObjectContainer();
+                IObjectContainer childContainer = new ObjectContainer(baseContainer);
+                var registration = baseContainer.RegisterFactoryAs(_ => new BlockingObject());
+                
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread1 = new Thread(_ => Assert.That(() => baseContainer.Resolve<BlockingObject>(name), Throws.Nothing));
+                var thread2 = new Thread(_ => Assert.That(() => childContainer.Resolve<BlockingObject>(name), Throws.Nothing));
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldBeAbleToResolveAllFromMultipleThreadsFromContainerHierarchyWhenRegisteredAsType(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                
+                IObjectContainer baseContainer = new ObjectContainer();
+                IObjectContainer childContainer = new ObjectContainer(baseContainer);
+                var registration = baseContainer.RegisterTypeAs<BlockingObject, BlockingObject>(name);
+                
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread1 = new Thread(_ => Assert.That(() => baseContainer.ResolveAll<BlockingObject>().ToList(), Throws.Nothing));
+                var thread2 = new Thread(_ => Assert.That(() => childContainer.ResolveAll<BlockingObject>().ToList(), Throws.Nothing));
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
+
+        [Test]
+        public void ShouldBeAbleToResolveAllFromMultipleThreadsFromContainerHierarchyWhenRegisteredAsFactory(
+            [Values(RegistrationStrategy.PerContext, RegistrationStrategy.PerDependency)] RegistrationStrategy registrationStrategy,
+            [Values(null, "Name")] string name)
+        {
+            try
+            {
+                
+                IObjectContainer baseContainer = new ObjectContainer();
+                IObjectContainer childContainer = new ObjectContainer(baseContainer);
+                var registration = baseContainer.RegisterFactoryAs(_ => new BlockingObject());
+                
+                ApplyRegistrationStrategy(registration, registrationStrategy);
+
+                var thread1 = new Thread(_ => Assert.That(() => baseContainer.ResolveAll<BlockingObject>().ToList(), Throws.Nothing));
+                var thread2 = new Thread(_ => Assert.That(() => childContainer.ResolveAll<BlockingObject>().ToList(), Throws.Nothing));
+                thread1.Start();
+                thread2.Start();
+
+                // try to wait until both object constructions are in progress (may not happen if no threading issue)
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                BlockingObject.ObjectsCreated.WaitOne(ForHalfASecond);
+                
+                // allow constructors to finish
+                BlockingObject.ConstructorBlockers[0].Set();
+                BlockingObject.ConstructorBlockers[1].Set();
+
+                // complete the threads
+                if (!thread1.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+                if (!thread2.Join(ForHalfASecond))
+                {
+                    Assert.Fail("Unable to complete resolution");
+                }
+            }
+            finally
+            {
+                BlockingObject.ResetBlockingEvents();
+            }
+        }
         
         private void ApplyRegistrationStrategy(IStrategyRegistration registration, RegistrationStrategy registrationStrategy)
         {

--- a/BoDi.Tests/RegisterFactoryDelegateTests.cs
+++ b/BoDi.Tests/RegisterFactoryDelegateTests.cs
@@ -86,7 +86,7 @@ namespace BoDi.Tests
 
         [Test/*, ExpectedException(typeof(ObjectContainerException), ExpectedMessage = "Circular dependency", MatchType = MessageMatch.Contains)*/]
         [Ignore("dynamic circles not detected yet, this leads to stack overflow")]
-        public void ShouldThrowExceptionForDynamicCircuarDepenencies()
+        public void ShouldThrowExceptionForDynamicCircularDependencies()
         {
             // given
 
@@ -98,7 +98,7 @@ namespace BoDi.Tests
         }
 
         [Test/*, ExpectedException(typeof(ObjectContainerException), ExpectedMessage = "Circular dependency", MatchType = MessageMatch.Contains)*/]
-        public void ShouldThrowExceptionForStaticCircuarDepenencies()
+        public void ShouldThrowExceptionForStaticCircularDependencies()
         {
             // given
 
@@ -111,7 +111,7 @@ namespace BoDi.Tests
         }
 
         [Test/*, ExpectedException(typeof(ObjectContainerException), ExpectedMessage = "Circular dependency", MatchType = MessageMatch.Contains)*/]
-        public void ShouldThrowExceptionForStaticCircuarDepenenciesWithMultipleFactoriesInPath()
+        public void ShouldThrowExceptionForStaticCircularDependenciesWithMultipleFactoriesInPath()
         {
             // given
 

--- a/BoDi.Tests/ResolveTests.cs
+++ b/BoDi.Tests/ResolveTests.cs
@@ -329,7 +329,7 @@ namespace BoDi.Tests
         }
 
         [Test/*, ExpectedException(typeof(ObjectContainerException), ExpectedMessage = "Circular dependency", MatchType = MessageMatch.Contains)*/]
-        public void ShouldThrowExceptionForCircuarDepenencies()
+        public void ShouldThrowExceptionForCircularDependencies()
         {
             // given
 

--- a/BoDi.sln
+++ b/BoDi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30711.63
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BoDi", "BoDi\BoDi.csproj", "{1A0FA4D4-67AA-4650-81E9-49E06F3B6CB9}"
 EndProject
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE.txt = LICENSE.txt
 		README.rdoc = README.rdoc
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BoDi.Performance.Tests", "BoDi.Performance.Tests\BoDi.Performance.Tests.csproj", "{462FC65C-8212-41B9-815C-CDFFCEBACEBE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +42,12 @@ Global
 		{EC40ACB0-A6B9-4776-9078-B1D72D244787}.LimitedRuntime_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC40ACB0-A6B9-4776-9078-B1D72D244787}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC40ACB0-A6B9-4776-9078-B1D72D244787}.Release|Any CPU.Build.0 = Release|Any CPU
+		{462FC65C-8212-41B9-815C-CDFFCEBACEBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{462FC65C-8212-41B9-815C-CDFFCEBACEBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{462FC65C-8212-41B9-815C-CDFFCEBACEBE}.LimitedRuntime_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{462FC65C-8212-41B9-815C-CDFFCEBACEBE}.LimitedRuntime_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{462FC65C-8212-41B9-815C-CDFFCEBACEBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{462FC65C-8212-41B9-815C-CDFFCEBACEBE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -588,7 +588,7 @@ namespace BoDi
 
         private bool isDisposed = false;
         private readonly ObjectContainer baseContainer;
-        private readonly Dictionary<RegistrationKey, IRegistration> registrations = new Dictionary<RegistrationKey, IRegistration>();
+        private readonly ConcurrentDictionary<RegistrationKey, IRegistration> registrations = new ConcurrentDictionary<RegistrationKey, IRegistration>();
         private readonly ResolvedKeys resolvedKeys = new ResolvedKeys();
         private readonly ObjectPool objectPool = new ObjectPool();
 
@@ -663,10 +663,7 @@ namespace BoDi
             if (key.Name != null)
             {
                 var dictKey = CreateNamedInstanceDictionaryKey(key.Type);
-                if (!registrations.ContainsKey(dictKey))
-                {
-                    registrations[dictKey] = new NamedInstanceDictionaryRegistration();
-                }
+                registrations.TryAdd(dictKey, new NamedInstanceDictionaryRegistration());
             }
         }
 
@@ -761,7 +758,7 @@ namespace BoDi
 
         private void ClearRegistrations(RegistrationKey registrationKey)
         {
-            registrations.Remove(registrationKey);
+            registrations.TryRemove(registrationKey, out _);
         }
 
 #if !BODI_LIMITEDRUNTIME && !BODI_DISABLECONFIGFILESUPPORT


### PR DESCRIPTION
Hi @gasparnagy ,

Following the discussions on BoDi thread-safety, I just took the time to write
* unit-tests demonstrating the issue
* code fixing these unit tests for resolution on the container level, ensuring locks are taken once, on the publicly exposed API, not impacting other internal calls, or not taking the several locks when using a container hierarchy. Note that:
    * #24 was aiming for registration and resolution thread-safety, but I assume it is safe to manage resolution only
    * #31 was only targeting base container access
* performance benchmark code to quantify performance impact


You will find below the results of the benchmarks.
As you can see, impact ranges from 3 to 7%, but this seems a very acceptable trade-off to me to gain thread safety, especially as resolution times are actually probably quite low with regards to the run time of code relying on BoDi, like SpecFlow.

Would be happy to have your view on this proposal!

``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
  DefaultJob : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
```
**ResolveFromType**
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Ratio | Rank |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|-----:|
|    v1.4 | 209.3 ns | 0.56 ns | 0.50 ns | 208.3 ns | 210.0 ns | 209.3 ns |  1.00 |    1 |
| Current | 223.0 ns | 0.55 ns | 0.51 ns | 221.9 ns | 223.8 ns | 223.1 ns |  1.07 |    2 |

**ResolveFromFactory**
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Ratio | Rank |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|-----:|
|    v1.4 | 226.2 ns | 1.38 ns | 1.15 ns | 224.5 ns | 228.4 ns | 226.1 ns |  1.00 |    1 |
| Current | 233.9 ns | 0.75 ns | 0.70 ns | 233.0 ns | 235.1 ns | 234.0 ns |  1.03 |    2 |

**ResolveAllFromType**
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Ratio | Rank |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|-----:|
|    v1.4 | 486.7 ns | 1.75 ns | 1.55 ns | 484.3 ns | 488.5 ns | 487.2 ns |  1.00 |    1 |
| Current | 516.8 ns | 1.55 ns | 1.21 ns | 513.4 ns | 518.0 ns | 517.0 ns |  1.06 |    2 |

**ResolveAllFromFactory**
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Ratio | Rank |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|-----:|
|    v1.4 | 499.4 ns | 1.72 ns | 1.53 ns | 496.5 ns | 502.3 ns | 499.4 ns |  1.00 |    1 |
| Current | 512.8 ns | 2.30 ns | 2.16 ns | 510.7 ns | 517.5 ns | 512.0 ns |  1.03 |    2 |