### PR TITLE
improve performance of RegistrationKey

### DIFF
--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromGenericType.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromGenericType.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveFromGenericType : SingleContainerBenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            return Container14.Resolve<IGenericRegistered<int>>();
+        }
+
+        [Benchmark(Description = "v1.BoDi_Concurrent_Dictionary_And_Lazy")]
+        public object Version_1_BoDi_Concurrent_Dictionary_And_Lazy()
+        {
+            return Container1Concurrent_Dictionary_And_Lazy.Resolve<IGenericRegistered<int>>();
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            return ContainerCurrent.Resolve<IGenericRegistered<int>>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/SingleContainerBenchmarkBase.cs
+++ b/BoDi.Performance.Tests/Benchmarks/SingleContainerBenchmarkBase.cs
@@ -6,19 +6,21 @@ namespace BODi.Performance.Tests.Benchmarks
 {
     [HtmlExporter]
     [MarkdownExporterAttribute.GitHub]
+    [MemoryDiagnoser]
     [MinColumn, MaxColumn, MeanColumn, MedianColumn, RankColumn]
     [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
     public abstract class SingleContainerBenchmarkBase
     {
-        protected internal IObjectContainer ContainerCurrent;
-        protected internal BoDi1_4.IObjectContainer Container14;
-        protected internal BoDi_Concurrent_Dictionary_And_Lazy.IObjectContainer Container1Concurrent_Dictionary_And_Lazy;
+        protected internal ObjectContainer ContainerCurrent;
+        protected internal BoDi1_4.ObjectContainer Container14;
+        protected internal BoDi_Concurrent_Dictionary_And_Lazy.ObjectContainer Container1Concurrent_Dictionary_And_Lazy;
 
         [GlobalSetup]
         public void Setup()
         {
             Container14 = new BoDi1_4.ObjectContainer();
             Container14.RegisterFactoryAs(_ => new FactoryRegistered());
+            Container14.RegisterTypeAs(typeof(GenericRegistered<>), typeof(IGenericRegistered<>));
             Container14.RegisterTypeAs<TypeRegistered, TypeRegistered>();
             Container14.RegisterTypeAs<AllRegistered1, IAllRegisteredFromType>();
             Container14.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
@@ -32,6 +34,7 @@ namespace BODi.Performance.Tests.Benchmarks
 
             Container1Concurrent_Dictionary_And_Lazy = new BoDi_Concurrent_Dictionary_And_Lazy.ObjectContainer();
             Container1Concurrent_Dictionary_And_Lazy.RegisterFactoryAs(_ => new FactoryRegistered());
+            Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs(typeof(GenericRegistered<>), typeof(IGenericRegistered<>));
             Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<TypeRegistered, TypeRegistered>();
             Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<AllRegistered1, IAllRegisteredFromType>();
             Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
@@ -44,6 +47,7 @@ namespace BODi.Performance.Tests.Benchmarks
 
             ContainerCurrent = new ObjectContainer();
             ContainerCurrent.RegisterFactoryAs(_ => new FactoryRegistered());
+            ContainerCurrent.RegisterTypeAs(typeof(GenericRegistered<>), typeof(IGenericRegistered<>));
             ContainerCurrent.RegisterTypeAs<TypeRegistered, TypeRegistered>();
             ContainerCurrent.RegisterTypeAs<AllRegistered1, IAllRegisteredFromType>();
             ContainerCurrent.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
@@ -53,8 +57,11 @@ namespace BODi.Performance.Tests.Benchmarks
             ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
             ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
             ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered4());
-
         }
+
+        protected internal interface IGenericRegistered<T> { }
+
+        protected internal class GenericRegistered<T> : IGenericRegistered<T> { }
 
         protected internal class FactoryRegistered { }
 

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -291,27 +291,17 @@ namespace BoDi
             }
         }
 
-        private struct RegistrationKey
+        private readonly struct RegistrationKey : IEquatable<RegistrationKey>
         {
             public readonly Type Type;
+            private readonly Type typeGroup;
             public readonly string Name;
 
             public RegistrationKey(Type type, string name)
             {
-                if (type == null) throw new ArgumentNullException("type");
-
-                Type = type;
+                Type = type ?? throw new ArgumentNullException(nameof(type));
+                typeGroup = (type.IsGenericType && !type.IsGenericTypeDefinition) ? type.GetGenericTypeDefinition() : type;
                 Name = name;
-            }
-
-            private Type TypeGroup
-            {
-                get
-                {
-                    if (Type.IsGenericType && !Type.IsGenericTypeDefinition)
-                        return Type.GetGenericTypeDefinition();
-                    return Type;
-                }
             }
 
             public override string ToString()
@@ -323,10 +313,10 @@ namespace BoDi
                 return string.Format("{0}('{1}')", Type.FullName, Name);
             }
 
-            bool Equals(RegistrationKey other)
+            public bool Equals(RegistrationKey other)
             {
-                var isInvertable = other.TypeGroup == Type || other.Type == TypeGroup || other.Type == Type;
-                return isInvertable && String.Equals(other.Name, Name, StringComparison.CurrentCultureIgnoreCase);
+                var isInvertable = other.Type == Type || other.typeGroup == Type || other.Type == typeGroup;
+                return isInvertable && other.Name == Name;
             }
 
             public override bool Equals(object obj)
@@ -338,10 +328,7 @@ namespace BoDi
 
             public override int GetHashCode()
             {
-                unchecked
-                {
-                    return TypeGroup.GetHashCode();
-                }
+                return typeGroup.GetHashCode();
             }
         }
 


### PR DESCRIPTION
PR 1 extracted out of #40 

Focused on the RegistrationKey.
2 main changes:
- Implement IEquateable to avoid boxing in equality / hashcode methods
- Cache the typegroup to improve the hashcode performance

Performance measurements:

From ResolveFromType, same performance, but less allocation
| Method |     Mean |   Error |  StdDev |        Min |        Max |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-----------:|--------:|--------:|-----------:|-----------:|-----------:|--------:|------:|------:|----------:|
| Current | 220.3 ns | 0.63 ns | 0.56 ns | 219.5 ns | 221.3 ns | 220.4 ns |  0.0730 |     - |     - |     344 B |
| Master | 221.8 ns | 2.19 ns | 1.94 ns | 220.3 ns | 226.7 ns | 220.9 ns |  0.0577 |     - |     - |     272 B |

From ResolveFromGenericType, faster performance, less allocations
|                                 Method |       Mean |   Error |  StdDev |        Min |        Max |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |-----------:|--------:|--------:|-----------:|-----------:|-----------:|-----:|------:|------:|----------:|
|                                Current |   676.1 ns | 5.69 ns | 5.32 ns |   669.4 ns |   685.6 ns |   674.6 ns |   0.0916 |     - |     - |     432 B |
|                                 Master |   877.2 ns | 5.14 ns | 4.81 ns |   869.9 ns |   884.2 ns |   877.6 ns |  0.1068 |     - |     - |     504 B |
|                                   v1.4 |   829.0 ns | 4.72 ns | 4.42 ns |   822.7 ns |   838.0 ns |   827.9 ns |  0.0639 |     - |     - |     304 B |
| v1.BoDi_Concurrent_Dictionary_And_Lazy | 1,026.5 ns | 4.18 ns | 3.70 ns | 1,020.5 ns | 1,032.4 ns | 1,025.6 ns | 0.1564 |     - |     - |     736 B |