### PR TITLE
improve allocation/performance of ResolutionList

### DIFF
--- a/BoDi.Performance.Tests/Benchmarks/ResolveFromTypeWithInnerTypes.cs
+++ b/BoDi.Performance.Tests/Benchmarks/ResolveFromTypeWithInnerTypes.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class ResolveFromTypeWithInnerTypes : SingleContainerBenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public object Version_1_4()
+        {
+            return Container14.Resolve<OuterClass>();
+        }
+
+        [Benchmark(Description = "v1.BoDi_Concurrent_Dictionary_And_Lazy")]
+        public object Version_1_BoDi_Concurrent_Dictionary_And_Lazy()
+        {
+            return Container1Concurrent_Dictionary_And_Lazy.Resolve<OuterClass>();
+        }
+
+        [Benchmark(Description = "Current")]
+        public object CurrentVersion()
+        {
+            return ContainerCurrent.Resolve<OuterClass>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/SingleContainerBenchmarkBase.cs
+++ b/BoDi.Performance.Tests/Benchmarks/SingleContainerBenchmarkBase.cs
@@ -6,6 +6,7 @@ namespace BODi.Performance.Tests.Benchmarks
 {
     [HtmlExporter]
     [MarkdownExporterAttribute.GitHub]
+    [MemoryDiagnoser]
     [MinColumn, MaxColumn, MeanColumn, MedianColumn, RankColumn]
     [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
     public abstract class SingleContainerBenchmarkBase
@@ -24,6 +25,9 @@ namespace BODi.Performance.Tests.Benchmarks
             Container14.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
             Container14.RegisterTypeAs<AllRegistered3, IAllRegisteredFromType>();
             Container14.RegisterTypeAs<AllRegistered4, IAllRegisteredFromType>();
+            Container14.RegisterTypeAs<InnerClass, InnerClass>();
+            Container14.RegisterTypeAs<MiddleClass, MiddleClass>();
+            Container14.RegisterTypeAs<OuterClass, OuterClass>();
             Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered1());
             Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
             Container14.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
@@ -37,6 +41,9 @@ namespace BODi.Performance.Tests.Benchmarks
             Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
             Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<AllRegistered3, IAllRegisteredFromType>();
             Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<AllRegistered4, IAllRegisteredFromType>();
+            Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<InnerClass, InnerClass>();
+            Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<MiddleClass, MiddleClass>();
+            Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<OuterClass, OuterClass>();
             Container1Concurrent_Dictionary_And_Lazy.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered1());
             Container1Concurrent_Dictionary_And_Lazy.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
             Container1Concurrent_Dictionary_And_Lazy.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
@@ -49,6 +56,9 @@ namespace BODi.Performance.Tests.Benchmarks
             ContainerCurrent.RegisterTypeAs<AllRegistered2, IAllRegisteredFromType>();
             ContainerCurrent.RegisterTypeAs<AllRegistered3, IAllRegisteredFromType>();
             ContainerCurrent.RegisterTypeAs<AllRegistered4, IAllRegisteredFromType>();
+            ContainerCurrent.RegisterTypeAs<InnerClass, InnerClass>();
+            ContainerCurrent.RegisterTypeAs<MiddleClass, MiddleClass>();
+            ContainerCurrent.RegisterTypeAs<OuterClass, OuterClass>();
             ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered1());
             ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered2());
             ContainerCurrent.RegisterFactoryAs<IAllRegisteredFromFactory>(_ => new AllRegistered3());
@@ -68,5 +78,16 @@ namespace BODi.Performance.Tests.Benchmarks
         private class AllRegistered2 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
         private class AllRegistered3 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
         private class AllRegistered4 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+
+        protected internal class InnerClass { }
+        protected internal class MiddleClass {
+            public MiddleClass(InnerClass innerClass) { }
+        }
+        protected internal class MiddleClass2 {
+            public MiddleClass2(TypeRegistered innerClass) { }
+        }
+        protected internal class OuterClass {
+            public OuterClass(MiddleClass first, MiddleClass2 second) { }
+        }
     }
 }


### PR DESCRIPTION
PR 2 extracted out of #40

Focused on ResolutionList
-  Avoid allocating a ResolutinoList if not needed
-  Improve performance of the Contains method

Performance measurements (purely this PR):
From ResolveFromType
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|-----:|-------:|------:|------:|----------:|
| Current | 223.8 ns | 1.26 ns | 1.18 ns | 221.6 ns | 225.7 ns | 223.6 ns |    1 | 0.0627 |     - |     - |     296 B |
| Master  | 226.5 ns | 1.43 ns | 1.34 ns | 224.5 ns | 229.2 ns | 227.1 ns |    1 | 0.0730 |     - |     - |     344 B |

From ResolveFromTypeWithInnerTypes 
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|-----:|-------:|------:|------:|----------:|
| Current | 319.3 ns | 2.11 ns | 1.97 ns | 316.2 ns | 322.2 ns | 319.6 ns |    1 | 0.0896 |     - |     - |     424 B |
| Master  | 325.4 ns | 2.31 ns | 2.16 ns | 322.5 ns | 328.7 ns | 324.9 ns |    1 | 0.1001 |     - |     - |     472 B |