### PR TITLE
Improve performance / allocations of RegisterAs* methods

### DIFF
--- a/BoDi.Performance.Tests/Benchmarks/RegisterInstance.cs
+++ b/BoDi.Performance.Tests/Benchmarks/RegisterInstance.cs
@@ -1,0 +1,27 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class RegisterInstance : SingleEmptyContainerBenchmarkBase
+    {
+        private readonly TypeRegistered instance = new TypeRegistered();
+
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public void Version_1_4()
+        {
+            Container14.RegisterInstanceAs(instance);
+        }
+
+        [Benchmark(Description = "v1.BoDi_Concurrent_Dictionary_And_Lazy")]
+        public void Version_1_BoDi_Concurrent_Dictionary_And_Lazy()
+        {
+            Container1Concurrent_Dictionary_And_Lazy.RegisterInstanceAs(instance);
+        }
+
+        [Benchmark(Description = "Current")]
+        public void CurrentVersion()
+        {
+            ContainerCurrent.RegisterInstanceAs(instance);
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/RegisterTypeAs.cs
+++ b/BoDi.Performance.Tests/Benchmarks/RegisterTypeAs.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class RegisterTypeAs : SingleEmptyContainerBenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public void Version_1_4()
+        {
+            Container14.RegisterTypeAs<TypeRegistered, TypeRegistered>();
+        }
+
+        [Benchmark(Description = "v1.BoDi_Concurrent_Dictionary_And_Lazy")]
+        public void Version_1_BoDi_Concurrent_Dictionary_And_Lazy()
+        {
+            Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<TypeRegistered, TypeRegistered>();
+        }
+
+        [Benchmark(Description = "Current")]
+        public void CurrentVersion()
+        {
+            ContainerCurrent.RegisterTypeAs<TypeRegistered, TypeRegistered>();
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/RegisterTypeAsName.cs
+++ b/BoDi.Performance.Tests/Benchmarks/RegisterTypeAsName.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    public class RegisterTypeAsName : SingleEmptyContainerBenchmarkBase
+    {
+        [Benchmark(Baseline = true, Description = "v1.4")]
+        public void Version_1_4()
+        {
+            Container14.RegisterTypeAs<TypeRegistered, TypeRegistered>("Name");
+        }
+
+        [Benchmark(Description = "v1.BoDi_Concurrent_Dictionary_And_Lazy")]
+        public void Version_1_BoDi_Concurrent_Dictionary_And_Lazy()
+        {
+            Container1Concurrent_Dictionary_And_Lazy.RegisterTypeAs<TypeRegistered, TypeRegistered>("Name");
+        }
+
+        [Benchmark(Description = "Current")]
+        public void CurrentVersion()
+        {
+            ContainerCurrent.RegisterTypeAs<TypeRegistered, TypeRegistered>("Name");
+        }
+    }
+}

--- a/BoDi.Performance.Tests/Benchmarks/SingleEmptyContainerBenchmarkBase.cs
+++ b/BoDi.Performance.Tests/Benchmarks/SingleEmptyContainerBenchmarkBase.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using BoDi;
+
+namespace BODi.Performance.Tests.Benchmarks
+{
+    [HtmlExporter]
+    [MarkdownExporterAttribute.GitHub]
+    [MemoryDiagnoser]
+    [MinColumn, MaxColumn, MeanColumn, MedianColumn, RankColumn]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
+    public abstract class SingleEmptyContainerBenchmarkBase
+    {
+        protected internal ObjectContainer ContainerCurrent;
+        protected internal BoDi1_4.ObjectContainer Container14;
+        protected internal BoDi_Concurrent_Dictionary_And_Lazy.ObjectContainer Container1Concurrent_Dictionary_And_Lazy;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Container14 = new BoDi1_4.ObjectContainer();
+            Container1Concurrent_Dictionary_And_Lazy = new BoDi_Concurrent_Dictionary_And_Lazy.ObjectContainer();
+            ContainerCurrent = new ObjectContainer();
+        }
+
+        protected internal class FactoryRegistered { }
+
+        protected internal class TypeRegistered { }
+
+        protected internal interface IAllRegisteredFromType { }
+
+        protected internal interface IAllRegisteredFromFactory { }
+
+        private class AllRegistered1 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+        private class AllRegistered2 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+        private class AllRegistered3 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+        private class AllRegistered4 : IAllRegisteredFromType, IAllRegisteredFromFactory {}
+    }
+}


### PR DESCRIPTION
PR 5 extracted out of #40

Focused on the RegisterAs methods

Main change:
- NamedInstanceDictionaryRegistration changed to a singleton as it contains no state
- Avoid calling TryRemove when we're anyway just set it to a new value anyway
- A bit of cleanup and reordering to simplify what the difference between the different RegisterAs methods are

Performance measurements:

RegisterTypeAsName
|                                 Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Ratio | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|-----:|-------:|------:|------:|----------:|
|                                Current | 627.5 ns | 1.79 ns | 1.58 ns | 625.4 ns | 630.0 ns | 627.6 ns |  1.05 |    2 | 0.0696 |     - |     - |     328 B |
|                                Master | 711.1 ns | 2.84 ns | 2.52 ns | 707.7 ns | 715.9 ns | 711.1 ns |  1.23 |    2 | 0.0858 |     - |     - |     408 B |

RegisterTypeAs
|                                 Method |      Mean |    Error |   StdDev |       Min |       Max |    Median | Ratio | RatioSD | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |----------:|---------:|---------:|----------:|----------:|----------:|------:|--------:|-----:|-------:|------:|------:|----------:|
|                                Current |  88.83 ns | 1.241 ns | 1.160 ns |  87.36 ns |  90.64 ns |  88.38 ns |  1.23 |    0.03 |    2 | 0.0204 |     - |     - |      96 B |
|                                Master| 146.97 ns | 1.455 ns | 1.361 ns | 144.89 ns | 148.69 ns | 147.37 ns |  2.06 |    0.02 |    2 | 0.0322 |     - |     - |     152 B |

RegisterInstance
|                                 Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Ratio | RatioSD | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|--------:|-----:|-------:|------:|------:|----------:|
|                                Current | 126.6 ns | 0.88 ns | 0.82 ns | 125.5 ns | 127.9 ns | 126.4 ns |  1.14 |    0.01 |    2 | 0.0186 |     - |     - |      88 B |
|                                Master | 184.4 ns | 1.26 ns | 1.18 ns | 182.8 ns | 186.6 ns | 184.4 ns |  1.66 |    0.02 |    2 | 0.0305 |     - |     - |     144 B |