### PR TITLE
do type checks when register, not when resolving

### DIFF
--- a/BoDi.Tests/RegisterTypeTests.cs
+++ b/BoDi.Tests/RegisterTypeTests.cs
@@ -114,6 +114,17 @@ namespace BoDi.Tests
         }
 
         [Test]
+        public void ShouldNotRegisterInvalidInterfaceType()
+        {
+            // given
+            var container = new ObjectContainer();
+
+            // then
+            Assert.Catch<ObjectContainerException>(() => container.RegisterTypeAs<IInterface1, IInterface1>());
+            Assert.Catch<ObjectContainerException>(() => container.RegisterTypeAs<IInterface1>(typeof(IInterface1)));
+        }
+
+        [Test]
         public void ShouldAlwaysCreateInstanceOnPerRequestStrategy()
         {
             // given


### PR DESCRIPTION
This PR wasn't actually part of #40 :) 

The goal of this PR is to do type checks as early as possible instead of every time we resolve.

Behavior change:
- The ObjectContainerException is now thrown upon registering an interface instead of when trying to resolve it.

Performance measurements:

ResolveFromType PerDependency
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|-----:|-------:|------:|------:|----------:|
| Current | 579.1 ns | 6.47 ns | 6.05 ns | 571.0 ns | 587.9 ns | 580.7 ns |    1 | 0.1459 |     - |     - |     688 B |
| Master | 627.1 ns | 3.38 ns | 3.16 ns | 621.7 ns | 630.4 ns | 628.3 ns |    1 | 0.1459 |     - |     - |     688 B |

ResolveFromType PerContext
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|-----:|-------:|------:|------:|----------:|
| Current | 195.3 ns | 0.48 ns | 0.45 ns | 194.5 ns | 196.3 ns | 195.3 ns |    1 | 0.0730 |     - |     - |     344 B |
| Master | 234.4 ns | 0.77 ns | 0.60 ns | 233.3 ns | 235.6 ns | 234.2 ns |    1 | 0.0730 |     - |     - |     344 B |

ResolveInstance
|  Method |     Mean |   Error |  StdDev |      Min |      Max |   Median | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|---------:|---------:|---------:|-----:|-------:|------:|------:|----------:|
| Current | 102.8 ns | 0.39 ns | 0.36 ns | 102.1 ns | 103.3 ns | 103.0 ns |    1 | 0.0237 |     - |     - |     112 B |
| Master | 138.9 ns | 0.86 ns | 0.76 ns | 137.4 ns | 140.3 ns | 139.0 ns |    1 | 0.0236 |     - |     - |     112 B |